### PR TITLE
Clear

### DIFF
--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -429,6 +429,31 @@ function genomeLineChart() {
       nestmap = d3.rollup(long_data, v => v[0], d => d.condition, d => d.metric_name, d => d.site)
       chart.data = nestmap;
 
+      // Handler for clear button change
+      clearbuttonchange = function() {
+        console.log('inside clear')
+        d3.selectAll(".selected").each(function(element){
+          var _circle = d3.select(this),
+              _circleData = _circle.data()[0]
+          // deselect the site on the PROTEIN
+          deselectSiteOnProteinStructure(":" + _circleData.protein_chain +
+            " and " + _circleData.protein_site);
+          // FOCUS styling and revert classes
+          _circle.style("fill", greyColor)
+            .classed("current_brushed", false)
+            .classed("brushed", false)
+            .classed("selected", false);
+        })
+        // LOGOPLOT includes all `.selected` (clicked or brushed) points
+        chart.brushedSites = d3.selectAll(".selected").data().map(d => +d
+          .site);
+        d3.select("#punchcard_chart")
+          .data([perSiteData.filter(d => chart.brushedSites.includes(+d.site))])
+          .call(punchCard);
+        // clear the physical brush (classification as 'brushed' remains)
+        focus.select(".brush").call(brushFocus.move, null);
+      };
+
       // Handler for dropdown value change
       dropdownChange = function() {
         current_condition = d3.select("#condition").property('value')

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -330,6 +330,7 @@ function genomeLineChart() {
         " and " + _circleData.protein_site);
       // FOCUS styling and revert classes
       _circle.style("fill", greyColor)
+        .attr("class", "non_brushed")
         .classed("current_brushed", false)
         .classed("brushed", false)
         .classed("selected", false);
@@ -440,9 +441,10 @@ function genomeLineChart() {
             " and " + _circleData.protein_site);
           // FOCUS styling and revert classes
           _circle.style("fill", greyColor)
-            .classed("current_brushed", false)
-            .classed("brushed", false)
-            .classed("selected", false);
+          .attr("class", "non_brushed")
+          .classed("current_brushed", false)
+          .classed("brushed", false)
+          .classed("selected", false)
         })
         // LOGOPLOT includes all `.selected` (clicked or brushed) points
         chart.brushedSites = d3.selectAll(".selected").data().map(d => +d
@@ -499,8 +501,8 @@ function genomeLineChart() {
           .classed("current_brushed", false)
           .classed("brushed", false)
           .classed("selected", false)
-          .classed("class", "current_brushed", false)
           .style("clip-path", "url(#clip)")
+          .style("fill", greyColor)
           .on("mouseover", showTooltip)
           .on("mouseout", hideTooltip)
           .on("click", clickOnPoint);

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -434,18 +434,17 @@ function genomeLineChart() {
       clearbuttonchange = function() {
         console.log('inside clear')
         d3.selectAll(".selected").each(function(element){
-          var _circle = d3.select(this),
-              _circleData = _circle.data()[0]
-          // deselect the site on the PROTEIN
-          deselectSiteOnProteinStructure(":" + _circleData.protein_chain +
-            " and " + _circleData.protein_site);
-          // FOCUS styling and revert classes
-          _circle.style("fill", greyColor)
+          d3.select(this).style("fill", greyColor)
           .attr("class", "non_brushed")
           .classed("current_brushed", false)
           .classed("brushed", false)
           .classed("selected", false)
+          
+          // deselect the site on the PROTEIN
+          var _d = d3.select(this).data()[0]
+          deselectSiteOnProteinStructure(":" + _d.protein_chain + " and " + _d.protein_site);
         })
+
         // LOGOPLOT includes all `.selected` (clicked or brushed) points
         chart.brushedSites = d3.selectAll(".selected").data().map(d => +d
           .site);

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -10,6 +10,7 @@ var dataPath = "_data/IAV/flu_dms-view.csv";
 var proteinPath = "_data/IAV/4O5N_trimer.pdb";
 var mut_metric = "mut_diffsel";
 var dropdownChange;
+var clearbuttonchange;
 
 var protein;
 var greyColor = "#999999";
@@ -97,6 +98,13 @@ window.addEventListener('DOMContentLoaded', (event) => {
         .insert("select", "svg")
         .attr("id", 'site')
         .on("change", dropdownChange);
+
+      var clearButton = d3.select("#line_plot")
+        .append("button")
+        .text("clear selections")
+        .attr("id", "clearButton")
+        .classed("button", true)
+        .on('click', clearbuttonchange);
 
       conditiondropdown.selectAll("option")
         .data(conditions)


### PR DESCRIPTION
This pull request adds a "clear selection" button.  When the button is clicked, the color and class of the `selected` points are reverted and removed from the protein structure. Then the logoplot is called without any sites. 

A lot of this code is repeated in the brush function. In the future it might make sense to have a "deselect" function that is called from the brush and from the clear button. 