### PR TITLE
Support negative mutation metrics in logo plots

### DIFF
--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -434,7 +434,7 @@ function genomeLineChart() {
               "label_site": row["label_site"],
               "mutation": row["mutation"],
               "condition": row["condition"],
-              "metric": Math.abs(+row[colname]),
+              "metric": +row[colname],
               "metric_name": colname
             });
           }


### PR DESCRIPTION
Enables plotting of residue logos for negative and positive metric values. This works by splitting the residue values per site into positive plus zero and negative sets and then plotting the positive values up from a baseline of y = 0 and plotting negative values down from the same baseline.

This PR does not attempt to align aesthetics of logoplots with [dmslogo](https://jbloomlab.github.io/dmslogo/), but that could be addressed in a future issue if it is critical.

Closes #55.