### PR TITLE
Refactor brush selection classes

### DIFF
--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -230,15 +230,16 @@ function genomeLineChart() {
   function clickOnPoint(d) {
     // update FOCUS and PROTEIN
     if (!d3.select(this).classed("selected")) {
-      selectSite(d3.select(this), d)
+      selectSite(d3.select(this))
     }else {
-      deselectSite(d3.select(this), d)
+      deselectSite(d3.select(this))
     }
     // update the LOGOPLOT
     updateLogoPlot();
   }
 
-  var selectSite = function(circlePoint, circleData){
+  var selectSite = function(circlePoint){
+      var circleData = circlePoint.data()[0];
       // update the FOCUS plot
        circlePoint.style("fill", color_key[circleData.site])
         .style("stroke-width", "1px")
@@ -253,7 +254,8 @@ function genomeLineChart() {
     });
   };
 
-  var deselectSite = function(circlePoint, circleData){
+  var deselectSite = function(circlePoint){
+    var circleData = circlePoint.data()[0];
     // update FOCUS plot
     circlePoint.style("fill", greyColor)
       .style("stroke-width", "0px")
@@ -270,10 +272,11 @@ function genomeLineChart() {
 
   var updateLogoPlot = function(){
     // LOGOPLOT includes all `.selected`points
-    chart.brushedSites = d3.selectAll(".selected").data().map(d => +d.site);
+    chart.selectedSites = d3.selectAll(".selected").data().map(d => +d.site);
     d3.select("#punchcard_chart")
-      .data([chart.condition_mut_data.filter(d => chart.brushedSites.includes(d.site))])
+      .data([chart.condition_mut_data.filter(d => chart.selectedSites.includes(d.site))])
       .call(punchCard);
+    console.log("Selected sites: ", chart.selectedSites)
   };
 
   // determines if a point is in the brush or not
@@ -317,17 +320,13 @@ function genomeLineChart() {
       if(brushType == 'select'){
         targets = _.without.apply(_, [brushed].concat(selected));
         targets.forEach(function(target) {
-          var _circle = d3.select("#site_" + target), // select the point
-              _circleData = _circle.data()[0]; // grab the data
-          selectSite(_circle, _circleData)
+          selectSite(d3.select("#site_" + target))
         });
 
       }else if(brushType == 'deselect'){
         targets = brushed.filter(value => selected.includes(value))
         targets.forEach(function(target) {
-          var _circle = d3.select("#site_" + target), // select the point
-              _circleData = _circle.data()[0]; // grab the data
-          deselectSite(_circle, _circleData)
+          deselectSite(d3.select("#site_" + target))
         });
 
       }else{
@@ -420,11 +419,7 @@ function genomeLineChart() {
           })
         })
 
-        // LOGOPLOT includes all `.selected` points
-        chart.brushedSites = d3.selectAll(".selected").data().map(d => +d.site);
-        d3.select("#punchcard_chart")
-          .data([chart.condition_mut_data.filter(d => chart.brushedSites.includes(d.site))])
-          .call(punchCard);
+        updateLogoPlot();
         // clear the physical brush (classification as 'brushed' remains)
         focus.select(".brush").call(brushFocus.move, null);
       };
@@ -455,11 +450,7 @@ function genomeLineChart() {
         chart.condition_data = chart.data.get(current_condition).get(current_site);
         chart.condition_mut_data = chart.mutData.get(current_condition).get(current_mut_metric);
         updateChart(chart.condition_data);
-
-        chart.selectedSites = d3.selectAll(".selected").data().map(d => +d.site);
-        d3.select("#punchcard_chart")
-          .data([chart.condition_mut_data.filter(d => chart.selectedSites.includes(d.site))])
-          .call(punchCard);
+        updateLogoPlot();
       };
 
       function updateChart(dataMap) {

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -490,22 +490,9 @@ function genomeLineChart() {
         // Remove old ones
         circlePoint.exit().remove();
 
-       // update the colors
-       d3.selectAll(".selected").data().map(d => +d.site).forEach(function(site) {
-         var _circle = d3.select("#site_" + site), // select the point
-             _circleData = _circle.data()[0]; // grab the data
-
-         // select the site on the PROTEIN
-         _circleData.protein_chain.forEach(function(chain){
-           selectSiteOnProtein(":" + chain + " and " +
-             _circleData.protein_site,
-             color_key[_circleData.site]);
-         })
-
-
-        // color the point in the FOCUS plot
-         _circle.style("fill", color_key[_circleData.site])
-       });
+        d3.selectAll(".selected").each(function(){
+          selectSite(d3.select(this))
+        })
 
         // fix the axes (including labels)
         focus.select("#axis_y_focus")

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -143,27 +143,6 @@ function genomeLineChart() {
     return colors;
   };
 
-
-  // selection by mouse click
-  function clickOnPoint(d) {
-    /*
-    Select or deselect a point using mouse click.
-    Updates both the PROTEIN structure and the LOGOPLOTS.
-    */
-
-    // if not already selected
-    if (!d3.select(this).classed("selected")) {
-      selectSite(d3.select(this), d)
-    }
-
-    // if the point is already selected
-    else {
-      deselectSite(d3.select(this), d)
-    }
-    // update the LOGOPLOT
-    updateLogoPlot();
-  }
-
   // Create the x-axis for the focus plot.
   focus.append("g")
     .attr("class", "axis axis--x")
@@ -247,6 +226,18 @@ function genomeLineChart() {
     context.select(".brush").call(brushContext.move, x.range().map(t.invertX, t));
   }
 
+  // selection by mouse click
+  function clickOnPoint(d) {
+    // update FOCUS and PROTEIN
+    if (!d3.select(this).classed("selected")) {
+      selectSite(d3.select(this), d)
+    }else {
+      deselectSite(d3.select(this), d)
+    }
+    // update the LOGOPLOT
+    updateLogoPlot();
+  }
+
   var selectSite = function(circlePoint, circleData){
       // update the FOCUS plot
        circlePoint.style("fill", color_key[circleData.site])
@@ -271,9 +262,8 @@ function genomeLineChart() {
       .classed("selected", false);
 
       // update PROTEIN structure
-      // update the PROTEIN structure
       circleData.protein_chain.forEach(function(chain){
-        deselectSiteOnProteinStructure(":" + chain + " and " +
+        deselectSiteOnProtein(":" + chain + " and " +
           circleData.protein_site);
       });
   };
@@ -290,7 +280,7 @@ function genomeLineChart() {
     // for each site to select, update the PROTEIN and the FOCUS point
     sites_to_deselect.forEach(function(element) {
       var _circle = d3.select("#site_" + element), // select the point
-        _circleData = _circle.data()[0]; // grab the data
+          _circleData = _circle.data()[0]; // grab the data
       deselectSite(_circle, _circleData);
     });
 
@@ -448,7 +438,7 @@ function genomeLineChart() {
           // deselect the site on the PROTEIN
           var _d = d3.select(this).data()[0]
           _d.protein_chain.forEach(function(chain){
-            deselectSiteOnProteinStructure(":" + chain + " and " + _d.protein_site);
+            deselectSiteOnProtein(":" + chain + " and " + _d.protein_site);
           })
         })
 

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -154,12 +154,6 @@ function genomeLineChart() {
     // if not already selected
     if (!d3.select(this).classed("selected")) {
       selectSite(d3.select(this), d)
-      // update the PROTEIN structure (color based on metric)
-      d.protein_chain.forEach(function(chain){
-        selectSiteOnProtein(":" + chain + " and " + d.protein_site,
-          color_key[d.site])
-      })
-
     }
 
     // if the point is already selected

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -158,8 +158,7 @@ function genomeLineChart() {
         .style("fill", color_key[d.site])
         .style("stroke-width", "1px")
         .style("opacity", selected_opacity)
-        .classed("selected", true)
-        .classed("clicked", true);
+        .classed("selected", true);
       // update the PROTEIN structure (color based on metric)
       d.protein_chain.forEach(function(chain){
         selectSiteOnProtein(":" + chain + " and " + d.protein_site,
@@ -175,8 +174,7 @@ function genomeLineChart() {
         .style('fill', 'grey')
         .style("stroke-width", "0px")
         .style("opacity", unselected_opacity)
-        .classed("selected", false)
-        .classed("clicked", false);
+        .classed("selected", false);
       // update the PROTEIN structure (baseline grey)
       d.protein_chain.forEach(function(chain){
         deselectSiteOnProteinStructure(":" + chain + " and " + d.protein_site)
@@ -321,37 +319,31 @@ function genomeLineChart() {
     A point will be selected if it is
     1. in the FOCUS brush area _and_
     2. was not previously in the FOCUS brush area _and_
-    3. is not *clicked*
     These points will also be colored by the value of the site-level metric
     and classed as `selected`.
 
     A point will be deselected if it is
     1. outside the FOCUS brush area _and_
     2. was previously in the FOCUS brush area _and_
-    3. is *not clicked*
     These points will also be colored the baseline grey and will no longer
     be classed as `selected`.
     */
 
-    // which sites are clicked? brushed? brushed but brushed before?
-    var clicked = d3.selectAll(".clicked").data().map(d => +d.site),
-      current_brushed = d3.selectAll(".current_brushed").data().map(d => +d
+    // which sites brushed? brushed but brushed before?
+    var current_brushed = d3.selectAll(".current_brushed").data().map(d => +d
         .site),
       already_brushed = d3.selectAll(".current_brushed.brushed").data().map(
         d => +d.site),
       previous_brush = d3.selectAll(".previous_brush").data().map(d=>+d.site);
 
-    // sites to select - `current_brushed` but not `clicked` or `brushed`.
+    // sites to select - `current_brushed` but not or `brushed`.
     var sites_to_select = _.without.apply(_, [current_brushed].concat(
         already_brushed)),
-      sites_to_select = _.without.apply(_, [sites_to_select].concat(clicked)),
       sites_to_select = _.without.apply(_, [sites_to_select].concat(previous_brush));
 
-    // sites to deselect - `non_brushed` but previously `brushed` but not `clicked`
+    // sites to deselect - `non_brushed` but previously `brushed`
     var sites_to_deselect = d3.selectAll(".non_brushed.brushed").data().map(
         d => +d.site),
-      sites_to_deselect = _.without.apply(_, [sites_to_deselect].concat(
-        clicked));
     sites_to_deselect = _.without.apply(_, [sites_to_deselect].concat(previous_brush));
 
     // for each site to select, update the PROTEIN and the FOCUS point
@@ -379,7 +371,7 @@ function genomeLineChart() {
   };
 
   var updateLogoPlot = function(){
-    // LOGOPLOT includes all `.selected` (clicked or brushed) points
+    // LOGOPLOT includes all `.selected`points
     chart.brushedSites = d3.selectAll(".selected").data().map(d => +d.site);
     d3.select("#punchcard_chart")
       .data([chart.condition_mut_data.filter(d => chart.brushedSites.includes(d.site))])
@@ -520,7 +512,7 @@ function genomeLineChart() {
           })
         })
 
-        // LOGOPLOT includes all `.selected` (clicked or brushed) points
+        // LOGOPLOT includes all `.selected` points
         chart.brushedSites = d3.selectAll(".selected").data().map(d => +d.site);
         d3.select("#punchcard_chart")
           .data([chart.condition_mut_data.filter(d => chart.brushedSites.includes(d.site))])

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -160,11 +160,8 @@ function genomeLineChart() {
     else {
       deselectSite(d3.select(this), d)
     }
-    
     // update the LOGOPLOT
-    d3.select("#punchcard_chart")
-      .data([chart.condition_mut_data.filter(d => chart.selectedSites.includes(d.site))])
-      .call(punchCard);
+    updateLogoPlot();
   }
 
   // Create the x-axis for the focus plot.

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -153,12 +153,7 @@ function genomeLineChart() {
 
     // if not already selected
     if (!d3.select(this).classed("selected")) {
-      // update the point on the LINE plot (color based on metric)
-      d3.select(this)
-        .style("fill", color_key[d.site])
-        .style("stroke-width", "1px")
-        .style("opacity", selected_opacity)
-        .classed("selected", true);
+      selectSite(d3.select(this), d)
       // update the PROTEIN structure (color based on metric)
       d.protein_chain.forEach(function(chain){
         selectSiteOnProtein(":" + chain + " and " + d.protein_site,

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -404,19 +404,8 @@ function genomeLineChart() {
 
       // Handler for clear button change
       clearbuttonchange = function() {
-        d3.selectAll(".selected").each(function(element){
-          d3.select(this).style("fill", greyColor)
-          .style("stroke-width", "0px")
-          .style("opacity", unselected_opacity)
-          .attr("class", "non_brushed")
-          .classed("brushed", false)
-          .classed("selected", false)
-
-          // deselect the site on the PROTEIN
-          var _d = d3.select(this).data()[0]
-          _d.protein_chain.forEach(function(chain){
-            deselectSiteOnProtein(":" + chain + " and " + _d.protein_site);
-          })
+        d3.selectAll(".selected").each(function(){
+          deselectSite(d3.select(this))
         })
 
         updateLogoPlot();

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -310,6 +310,21 @@ function genomeLineChart() {
 
   };
 
+  var selectSite = function(circlePoint, circleData){
+      // update the FOCUS plot
+       circlePoint.style("fill", color_key[circleData.site])
+        .style("stroke-width", "1px")
+        .style("opacity", selected_opacity)
+        .classed("selected", true);
+
+    // update the PROTEIN structure
+    circleData.protein_chain.forEach(function(chain){
+      selectSiteOnProtein(":" + chain + " and " +
+        circleData.protein_site,
+        color_key[circleData.site]);
+    });
+  };
+
   var brushPointsFocusSelection = function() {
     // we want to select sites which are in the current brush but have not been selected before
     var selected = d3.selectAll(".selected").data().map(d => +d.site),
@@ -321,19 +336,7 @@ function genomeLineChart() {
       var _circle = d3.select("#site_" + element), // select the point
           _circleData = _circle.data()[0]; // grab the data
 
-    // update the FOCUS plot
-    _circle.style("fill", color_key[_circleData.site])
-      .style("stroke-width", "1px")
-      .style("opacity", selected_opacity)
-      .classed("selected", true);
-
-      // update the PROTEIN structure
-      _circleData.protein_chain.forEach(function(chain){
-        selectSiteOnProtein(":" + chain + " and " +
-          _circleData.protein_site,
-          color_key[_circleData.site]);
-      })
-
+      selectSite(_circle, _circleData)
     });
 
     // all points in the current FOCUS brush area have been processed
@@ -380,7 +383,7 @@ function genomeLineChart() {
         function(d) {
           return isBrushed(extent, d)
         });
-        
+
       // selection or deselection?
       if(brushType == 'select'){
           brushPointsFocusSelection();

--- a/docs/_javascript/prot_struct.js
+++ b/docs/_javascript/prot_struct.js
@@ -75,7 +75,7 @@ function selectSiteOnProtein(siteString, color) {
 }
 
 // remove color from a site
-function deselectSiteOnProteinStructure(siteString) {
+function deselectSiteOnProtein(siteString) {
   stage.getRepresentationsByName(siteString).dispose()
 }
 


### PR DESCRIPTION
This pull request cleans up the `line_plot_zoom.js` code. The main problem it fixes is duplicated code for selecting and deselecting sites. This was done through three main code changes: 

1. The creation of simple `selectSite` and `deselectSite` functions. This functions act on a single site. They can be used for sites that are clicked or sites that were brushed. 

2. Simplification of the brush logic. We had very complicated bookkeeping that was a hold-over from the previous single-brush-with-resize logic and the need to debounce a function. Now, we allow multiple brushes and don't do anything until brush end (so we don't need to debounce). This means that the only thing we need to keep track of is a) is the point selected? b) is the point brushed? 

3. All of the code uses the same function for the same behavior. Previously, we were selecting points by copying and pasting code. Now if a point needs to be selected/deselected (by brushing, by clicking, by updating the chart, by clearing the selections, etc) it is all done through the same functions. I also made sure that updating the logoplots was all done through the same function. 

Lingering concerns: 
Right now, selecting/deselecting points and updating the logoplot are decoupled. Generally the way that it works is you look over a list of sites to select/deselect and then you call updateLogoPlot. This is not necessarily bad but just something to keep in mind. 