### PR TITLE
anchor the center of the text

### DIFF
--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -174,7 +174,8 @@ function genomeLineChart() {
     // Set y-axis label for the focus plot.
     svg
       .append("text")
-      .attr("transform", "translate(" + (12) + ", " + (plotHeightFocus - -10) + ") rotate(-90)")
+      .attr("transform", "translate(" + (12) + ", " + (plotHeightFocus - 85) + ") rotate(-90)")
+      .style("text-anchor", "middle")
       .attr("id", "context_y_label");
 
   // Set title for the context plot.

--- a/docs/_javascript/logoplot.js
+++ b/docs/_javascript/logoplot.js
@@ -44,7 +44,8 @@ function logoplotChart(selection) {
   // Set y-axis label.
   svg
     .append("text")
-    .attr("transform", "translate(" + (12) + ", " + (height - 40) + ") rotate(-90)")
+    .attr("transform", "translate(" + (12) + ", " + (height - 80) + ") rotate(-90)")
+    .style("text-anchor", "middle")
     .attr("id", "logoplot_y_label");
 
   // Create a genome line chart for the given selection.


### PR DESCRIPTION
This pull request (partially) fixes the placement of the y-axis labels. Would close issue #74.

We want the y-axis labels to update when the site metric or the mutation metric update. Previously, the start of the label had been hard coded which meant that labels of different lengths looked very different. To fix this problem, I specified that y-axis label should be center anchored. This means that whatever coordinates we give the y-axis label, the string will be centered on these coordinates. 

What this pull request does not fix is what happens if the site label is _very_ long. We might want to create a wrap function, such as the one found here: https://bl.ocks.org/mbostock/7555321. However, this seems like an infrequent case and one that the user has some control over (they can shorten the names themselves), so I think we should address this down the road. 