### PR TITLE
Rename logoplot code from "punchcard" to "logoplot"

### DIFF
--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -273,9 +273,9 @@ function genomeLineChart() {
   var updateLogoPlot = function(){
     // LOGOPLOT includes all `.selected`points
     chart.selectedSites = d3.selectAll(".selected").data().map(d => +d.site);
-    d3.select("#punchcard_chart")
+    d3.select("#logo_plot")
       .data([chart.condition_mut_data.filter(d => chart.selectedSites.includes(d.site))])
-      .call(punchCard);
+      .call(logoplot);
     console.log("Selected sites: ", chart.selectedSites)
   };
 

--- a/docs/_javascript/logoplot.js
+++ b/docs/_javascript/logoplot.js
@@ -1,4 +1,4 @@
-function punchCardChart(selection) {
+function logoplotChart(selection) {
   var colorScheme = 'functional';
   var divWidth = 760,
       divHeight = 250,
@@ -45,7 +45,7 @@ function punchCardChart(selection) {
   svg
     .append("text")
     .attr("transform", "translate(" + (12) + ", " + (height - 40) + ") rotate(-90)")
-    .attr("id", "punchcard_y_label");
+    .attr("id", "logoplot_y_label");
 
   // Create a genome line chart for the given selection.
   function chart(selection) {
@@ -159,11 +159,11 @@ function punchCardChart(selection) {
           return siteMap.get(site)["label"];
       }));
 
-      svg.select("#punchcard_y_label").text(metric_name.substring(4, ));
+      svg.select("#logoplot_y_label").text(metric_name.substring(4, ));
       svg.select(".y-axis").call(yAxis);
 
       // Create the base tooltip object.
-      const logoTooltip = d3.select("#punchcard_chart")
+      const logoTooltip = d3.select("#logo_plot")
         .append("div")
         .style("font-family", "'Open Sans', sans-serif")
         .style("text-align", "left")

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -5,7 +5,7 @@
  */
 var chart;
 var perSiteData;
-var punchCard;
+var logoplot;
 var dataPath = "_data/IAV/flu_dms-view.csv";
 var proteinPath = "_data/IAV/4O5N_trimer.pdb";
 
@@ -30,7 +30,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
   addElement(polymerSelect);
 
   // Initialize the mutation/site chart.
-  punchCard = punchCardChart("#punchcard_chart");
+  logoplot = logoplotChart("#logo_plot");
 
   // Request data for charts.
   var promise1 = d3.csv(dataPath).then(function(data) {
@@ -110,7 +110,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
           return d.substring(5, );
         })
 
-      var mutdropdown = d3.select("#punchcard_chart")
+      var mutdropdown = d3.select("#logo_plot")
         .insert("select", "svg")
         .attr("id", 'mutation_metric')
         .on("change", dropdownChange);

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
     <div class="row mb-5 border-top border-bottom pt-3 pb-3">
       <div class="col-8">
         <div id="line_plot" class="row"></div>
-        <div id="punchcard_chart" class="row"></div>
+        <div id="logo_plot" class="row"></div>
       </div>
       <div class="col-4">
         <div id="protein" style="width:400px; height:800px;"></div>
@@ -45,6 +45,6 @@
   <script src="_javascript/line_plot_zoom.js" type="text/javascript"></script>
   <script src="_javascript/ngl.js"></script>
   <script src="_javascript/prot_struct.js" type="text/javascript"></script>
-  <script src="_javascript/punchcard.js" type="text/javascript"></script>
+  <script src="_javascript/logoplot.js" type="text/javascript"></script>
 </body>
 </html>


### PR DESCRIPTION
Corrects the name of the plot that was originally going to be a punchcard,
clearing up confusion for the (code) reader and also sets us up to create the
actual punchcard plot as a separate script.