### PR TITLE
Sort sites for logo plot numerically

### DIFF
--- a/docs/_javascript/logoplot.js
+++ b/docs/_javascript/logoplot.js
@@ -51,7 +51,7 @@ function logoplotChart(selection) {
   // Create a genome line chart for the given selection.
   function chart(selection) {
     selection.each(function (data) {
-      var sites = [...new Set(data.map(d => d.site))].sort();
+      var sites = [...new Set(data.map(d => +d.site))].sort((a, b) => a - b);
       var mutations = [...new Set(data.map(d => d.mutation))].sort();
       if(data.length == 0){
         var metric_name = "";


### PR DESCRIPTION
Sites in the logo plot x-axis were originally being sorted alphanumerically which is why site 57 appeared before site 428.

Closes #77.