### PR TITLE
check if protein exists before selecting site

### DIFF
--- a/docs/_javascript/prot_struct.js
+++ b/docs/_javascript/prot_struct.js
@@ -69,10 +69,12 @@ function selectSiteOnProtein(siteString, color) {
     fill = polymerSelect.value
   }
   // color the site
+  if(protein){
   protein.addRepresentation(fill, {
     color: color,
     name: siteString
   }).setSelection(siteString)
+}
 }
 
 // remove color from a site


### PR DESCRIPTION
This PR checks to see if the protein exists before trying to add representation to the protein structure. This means that the site plot and the mutation plot selections work even if no protein structure is loaded. 

Close issue #93. 