### PR TITLE
Shift key for eraser

### DIFF
--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -59,7 +59,8 @@ function genomeLineChart() {
       [0, 0],
       [plotWidth, plotHeightFocus]
     ]).on("end", brushPoints)
-    .on("start", brushBegin),
+    .on("start", brushBegin)
+    .keyModifiers(false),
     zoomContext = d3.zoom()
     .scaleExtent([1, Infinity])
     .translateExtent([
@@ -449,7 +450,7 @@ function genomeLineChart() {
       // add listener pressing a key on the keyboard
       // if metaKey down, change brush to eraser
       window.addEventListener("keydown", event => {
-        if (event.metaKey) {
+        if (event.shiftKey) {
           document.getElementById('deselect').checked = true
           focus.classed("brush_select", false).classed("brush_deselect", true)
         }
@@ -468,17 +469,6 @@ function genomeLineChart() {
         } else if ( this.value === 'deselect' ) {
            focus.classed("brush_select", false).classed("brush_deselect", true)
         }
-      });
-
-      // add listener pressing a key on the keyboard
-      // if metaKey down, change brush to eraser
-      window.addEventListener("keydown", event => {
-        if (event.metaKey) {
-          document.getElementById('deselect').checked = true
-        }
-      });
-      window.addEventListener("keyup", event => {
-          document.getElementById('select').checked = true
       });
 
       // Handler for dropdown value change

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,8 +26,8 @@
         "Escape mutations" are defined as those mutations which are enriched, or positively differentially selected, in a cell-passage selection with serum compared to a mock cell-passage selection without serum.
         <h4>Instructions:</h4>
         Select points of interest by <span style="font-weight:bold">clicking</span> or <span style="font-weight:bold">brushing</span> (click, hold and swipe).
-        Deselect points by <span style="font-weight:bold">clicking</span> again or <span style="font-weight:bold">brushing</span> after changing the dropdown from <span style="font-style:italic">select</span> to <span style="font-style:italic">deselect</span>.
-        Change between different <span style="font-style:italic">sera</span>, different <span style="font-style:italic">site-level metrics</span> and different <span style="font-style:italic">mutation-level metrics</span> using the dropwdown menus.
+        Deselect points by <span style="font-weight:bold">clicking</span> again or <span style="font-weight:bold">brushing</span> while holding down the <span style="font-style:italic">shift key</span> or after changing the radio button from <span style="font-style:italic">select</span> to <span style="font-style:italic">deselect</span>.
+        Change between different <span style="font-style:italic">conditions</span>, different <span style="font-style:italic">site-level metrics</span>, different <span style="font-style:italic">mutation-level metrics</span> and different <span style="font-style:italic">protein-representations</span> using the dropwdown menus.
       </div>
     </div>
 


### PR DESCRIPTION
This PR changes the special key designation for the eraser. 

This took two steps. 
1. disable all key modifiers for the brush. The shift key has a special behavior for `d3.brush` and it is not easy to turn off just the shift key behavior. (See the long discussion [here](https://github.com/d3/d3-brush/issues/20)).  
2. Change the listener from `event.metaKey` to `event.shiftKey`. 

I also updated the on-screen instructions. 
