### PR TITLE
Allow users to dynamically define input data

### DIFF
--- a/docs/_data/IAV/lee2019mapping.md
+++ b/docs/_data/IAV/lee2019mapping.md
@@ -1,0 +1,23 @@
+# [Mapping person-to-person variation in viral mutations that escape polyclonal serum targeting influenza hemagglutinin](https://elifesciences.org/articles/49324)
+Juhye M Lee, Rachel Eguia, Seth J Zost, Saket Choudhary, Patrick C Wilson, Trevor Bedford, Terry Stevens-Ayers, Michael Boeckh, Aeron C Hurt, Seema S Lakdawala, Scott E Hensley, Jesse D Bloom
+
+## eLife Digest
+The human immune system protects the body from repeat attacks by remembering past infections. However, a typical person comes down with the flu every five to seven years. This is because flu viruses rapidly evolve to bypass our defenses. So, after a few years, the viruses look so different that the immune system no longer recognizes them.  
+
+The immune system recognizes flu viruses by producing proteins known as antibodies, which can bind to the virus and prevent it from infecting cells. Many of these antibodies bind to a protein on the surface of the virus called hemagglutinin, but each anti-flu antibody recognizes only a small region of the protein. This means that to escape recognition by a single antibody, all the virus needs to do is wait for a lucky mutation to change the part of hemagglutinin recognized by that antibody. But humans make many different antibodies. To escape them all, flu viruses would need lots of lucky mutations. So how do flu viruses keep winning the evolutionary lottery?
+
+To answer this question, Lee et al. made all the possible individual mutations to the hemagglutinin protein of a human flu virus. A pool of these viruses was then exposed to the full mix of antibodies present in human serum (the liquid component of blood). Lee et al. then checked which mutations helped the virus survive contact with the antibodies. For most human serum samples, a single mutation was enough to allow the virus to escape most of one person’s anti-flu antibodies. This suggests that the immune response to flu is so focused on a small region of hemagglutinin that a mutation in this region can enable the virus to take a huge step towards evading immune detection.
+
+Even more surprising was what happened when Lee et al. looked at serum from different people. A mutation that helped the virus to escape immune detection in one person often had little or no effect on escape from another person’s immunity. In other words, the lucky mutation that the virus needed to escape differed from one person to the next.
+
+Every year there are many related flu viruses that infect humans. The results of Lee et al. suggest that people could be susceptible to different forms of the virus. Understanding how flu viruses escape immune detection in different people could help us identify which version of the virus different people are more susceptible to, and perhaps eventually better predict how the virus will evolve and spread.
+
+## What data is shown here?
+
+We are showing the complete datasets for the sera shown in [Figure 3](https://elifesciences.org/articles/49324#fig3) of the paper.
+
+
+## Where can I find out more?
+
+- [link to paper](https://elifesciences.org/articles/49324)  
+- [link to Github repo](https://github.com/jbloomlab/map_flu_serum_Perth2009_H3_HA)

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -72,7 +72,7 @@ function genomeLineChart() {
       [plotWidth, plotHeightContext]
     ]).on("zoom", zoomed),
     missingData = [undefined, null, NaN, false, ""],
-    brushTypem,
+    brushType,
     lastBrushTypeClick='select';
 
   // Create the base chart SVG object.
@@ -300,8 +300,9 @@ function genomeLineChart() {
 
   // determines if a point is in the brush or not
   function isBrushed(brush_coords, d) {
-    cx = xScaleFocus(d.site);
-    cy = yScaleFocus(d.metric);
+    const cx = xScaleFocus(+d.site);
+    const cy = yScaleFocus(+d.metric);
+
     if (brush_coords == null) {
       return false
     } else {
@@ -315,11 +316,11 @@ function genomeLineChart() {
 
   function brushBegin() {
     if(document.getElementById('select').checked){
-      brushType="select"
+      brushType="select";
     }else if(document.getElementById('deselect').checked){
-      brushType="deselect"
+      brushType="deselect";
   }else{
-    brushType="wrong"
+    brushType="wrong";
   }
 };
 
@@ -329,7 +330,7 @@ function genomeLineChart() {
     updates PROTEIN structure and LOGOPLOTS based on the brush selection
     from the CONTEXT plot.
     */
-    var extent = d3.event.selection // FOCUS brush's coordinates
+    var extent = d3.event.selection; // FOCUS brush's coordinates
 
     if(extent){
       // a point is either in the newly brushed area or it is not
@@ -337,7 +338,7 @@ function genomeLineChart() {
 
       circlePoint.classed("brushed",
         function(d) {
-          return isBrushed(extent, d)
+          return isBrushed(extent, d);
         });
 
       var selected = d3.selectAll(".selected").data().map(d => +d.site),
@@ -348,7 +349,7 @@ function genomeLineChart() {
       if(brushType === "select"){
         targets = _.without.apply(_, [brushed].concat(selected));
         targets.forEach(function(target) {
-          selectSite(d3.select("#site_" + target))
+          selectSite(d3.select("#site_" + target));
         });
 
       }else if(brushType === "deselect"){
@@ -484,7 +485,7 @@ function genomeLineChart() {
       };
 
       function updateChart(dataMap) {
-        data = Array.from(dataMap.values())
+        const data = Array.from(dataMap.values());
 
         // extract y-axis label from metric_name
         svg.select("#context_y_label")

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -610,5 +610,8 @@ function genomeLineChart() {
     return chart;
   };
 
+  // Expose the function to select individual sites.
+  chart.selectSite = selectSite;
+
   return chart;
 } // end of genomeLineChart

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -510,15 +510,6 @@ function genomeLineChart() {
           }
         };
         const transition = svg.transition().duration(500);
-        function colorSelectedCircles (d) {
-          if (d3.select(this).classed("selected")) {
-            return color_key[d.site];
-          }
-          else {
-            return greyColor;
-          }
-        }
-
         const circlePoint = focus.selectAll("circle")
             .data(data)
             .join(
@@ -539,11 +530,14 @@ function genomeLineChart() {
               update => update.attr("r", radius)
                 .attr("cx", XFocus)
                 .attr("id", d => "site_" + d.site)
-                .style("fill", colorSelectedCircles)
                 .call(update => update.transition(transition)
                       .attr("cy", YFocus)),
               exit => exit.remove()
             );
+
+        d3.selectAll(".selected").each(function(){
+          selectSite(d3.select(this));
+        });
 
         // fix the axes (including labels)
         focus.select("#axis_y_focus")

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -499,47 +499,41 @@ function genomeLineChart() {
         xScaleContext.domain(xScaleFocus.domain());
         yScaleContext.domain(yScaleFocus.domain());
 
-        // Create the context plot, drawing a line through all of the data points.
-        // focus.selectAll("path.line")
-        //   .data([data])
-        //   .join("path")
-        //   .attr("class", "line")
-        //   .style("clip-path", "url(#clip)")
-        //   .attr("d", lineFocus);
-
         // Plot a circle for each site in the given data.
-        var circlePoint = focus.selectAll("circle").data(data);
+        const radius = (d) => {
+          if(d.metric == undefined) {
+            return 0;
+          }
+          else {
+            return 5;
+          }
+        };
+        const transition = svg.transition().duration(500);
 
-        circlePoint.enter()
-          .append("circle")
-          .attr("r", function(d){if(d.metric == undefined){return 0}else{return 5}})
-          .attr("cx", XFocus)
-          .attr("cy", YFocus)
-          .attr("id", d => "site_" + d.site)
-          .attr("class", "non_brushed")
-          .classed("brushed", false)
-          .classed("selected", false)
-          .style("clip-path", "url(#clip)")
-          .style("fill", greyColor)
-          .style("opacity", unselected_opacity)
-          .style("stroke", "grey")
-          .style("stroke-width", "0px")
-          .on("mouseover", showTooltip)
-          .on("mouseout", hideTooltip)
-          .on("click", clickOnPoint);
-
-        // Update old ones, already have x / width from before
-        circlePoint
-          .transition().duration(250)
-          .attr("cy", YFocus)
-          .attr("r", function(d){if(d.metric == undefined){return 0}else{return 5}});
-
-        // Remove old ones
-        circlePoint.exit().remove();
-
-        d3.selectAll(".selected").each(function(){
-          selectSite(d3.select(this))
-        })
+        const circlePoint = focus.selectAll("circle")
+            .data(data)
+            .join(
+              enter => enter.append("circle")
+                .attr("r", radius)
+                .attr("cx", XFocus)
+                .attr("cy", YFocus)
+                .attr("id", d => "site_" + d.site)
+                .attr("class", "non_brushed")
+                .style("clip-path", "url(#clip)")
+                .style("fill", greyColor)
+                .style("opacity", unselected_opacity)
+                .style("stroke", "grey")
+                .style("stroke-width", "0px")
+                .on("mouseover", showTooltip)
+                .on("mouseout", hideTooltip)
+                .on("click", clickOnPoint),
+              update => update.attr("r", radius)
+                .attr("cx", XFocus)
+                .attr("id", d => "site_" + d.site)
+                .call(update => update.transition(transition)
+                      .attr("cy", YFocus)),
+              exit => exit.remove()
+            );
 
         // fix the axes (including labels)
         focus.select("#axis_y_focus")

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -528,7 +528,6 @@ function genomeLineChart() {
                 .on("mouseout", hideTooltip)
                 .on("click", clickOnPoint),
               update => update.attr("r", radius)
-                .attr("cx", XFocus)
                 .attr("id", d => "site_" + d.site)
                 .call(update => update.transition(transition)
                       .attr("cy", YFocus)),

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -610,6 +610,7 @@ function genomeLineChart() {
 
   // Expose the function to select individual sites.
   chart.selectSite = selectSite;
+  chart.updateLogoPlot = updateLogoPlot;
 
   return chart;
 } // end of genomeLineChart

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -509,6 +509,14 @@ function genomeLineChart() {
           }
         };
         const transition = svg.transition().duration(500);
+        function colorSelectedCircles (d) {
+          if (d3.select(this).classed("selected")) {
+            return color_key[d.site];
+          }
+          else {
+            return greyColor;
+          }
+        }
 
         const circlePoint = focus.selectAll("circle")
             .data(data)
@@ -530,6 +538,7 @@ function genomeLineChart() {
               update => update.attr("r", radius)
                 .attr("cx", XFocus)
                 .attr("id", d => "site_" + d.site)
+                .style("fill", colorSelectedCircles)
                 .call(update => update.transition(transition)
                       .attr("cy", YFocus)),
               exit => exit.remove()

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -114,13 +114,10 @@ function renderCsv(data) {
 
   // Select the site with the maximum y value by default.
   console.log("Select site with maximum y value");
-  var max_y_value = d3.max(Array.from(chart.condition_data.values()), d => +d.metric);
-  var max_y_record = Array.from(chart.condition_data.values()).filter(d => +d.metric == max_y_value);
-
-  if (max_y_record.length > 0) {
-    console.log("click site " + max_y_record[0].site);
-    d3.select("#site_" + max_y_record[0].site).dispatch("click");
-  }
+  const circles = d3.selectAll("circle");
+  const maxMetricIndex = d3.maxIndex(circles.data(), d => +d.metric);
+  const maxMetricRecord = d3.select(circles.nodes()[maxMetricIndex]);
+  chart.selectSite(maxMetricRecord);
 }
 
 function renderPdb(data) {

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -136,6 +136,14 @@ function renderPdb(data) {
     color: greyColor
   });
 
+  // If data have been loaded into the site plot, select any sites from that
+  // panel in the protein view, too.
+  if (chart !== undefined) {
+    d3.selectAll(".selected").each(function(){
+      chart.selectSite(d3.select(this));
+    });
+  }
+
   return protein;
 }
 

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -118,6 +118,7 @@ function renderCsv(data) {
   const maxMetricIndex = d3.maxIndex(circles.data(), d => +d.metric);
   const maxMetricRecord = d3.select(circles.nodes()[maxMetricIndex]);
   chart.selectSite(maxMetricRecord);
+  chart.updateLogoPlot();
 }
 
 function renderPdb(data) {

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -50,10 +50,7 @@ function renderCsv(data) {
     .data([data])
     .call(chart);
 
-  console.log(chart.data)
   let conditions = Array.from(chart.data.keys());
-  console.log("conditions:");
-  console.log(conditions);
   let site_metrics = Array.from(chart.data.get(conditions[0]).keys());
   let mut_metrics = Array.from(chart.mutData.get(conditions[0]).keys());
 

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -166,6 +166,7 @@ function renderDataUrl (dataUrl, dataFieldId, dataType) {
   else if (dataType === "pdb") {
     dataFunction = (d) => {
       stage.removeAllComponents();
+      stage.animationControls.clear()
       return stage.loadFile(d)
     };
     renderFunction = renderPdb;

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -73,6 +73,45 @@ window.addEventListener('DOMContentLoaded', (event) => {
       site_metrics = Array.from(chart.data.get(conditions[0]).keys());
       mut_metrics = Array.from(chart.mutData.get(conditions[0]).keys());
 
+      function renderMarkdown (data) {
+        console.log("Loaded markdown file with content:");
+        // Render Markdown text to HTML.
+        const markdownOutput = marked(data);
+        console.log(markdownOutput);
+
+        // If there is any rendered output, update the DOM.
+        if (markdownOutput.length > 0) {
+          d3.select("#markdown-output")
+            .html(markdownOutput);
+        }
+      }
+
+      // Check if the URL already provides a Markdown URL. If it does, use that
+      // URL to load and render the Markdown.
+      const url = new URL(window.location);
+      if (url.searchParams.get("markdown-url") !== null) {
+        d3.text(url.searchParams.get("markdown-url")).then(renderMarkdown);
+      }
+
+      function markdownButtonChange () {
+        // Try to load the user's provided URL to a Markdown document.
+        const markdownUrl = d3.select("#markdown-url").property('value');
+        console.log(markdownUrl);
+        if (markdownUrl.length > 0) {
+          d3.text(markdownUrl).then(renderMarkdown);
+
+          // Update the document's query string to reflect the requested URL.
+          // This should help maintain state if the user copies and pastes the
+          // document's URL.
+          const url = new URL(window.location);
+          url.searchParams.set("markdown-url", markdownUrl);
+          history.replaceState({}, "", url.toString());
+        }
+      }
+
+      var markdownButton = d3.select("#markdown-url-submit")
+        .on("click", markdownButtonChange);
+
       var clearButton = d3.select("#line_plot")
         .insert("button", "svg")
         .text("clear selections")

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -198,11 +198,17 @@ function renderDataUrl (dataUrl, dataFieldId, dataType) {
   });
 }
 
-function initializeDataUrl(dataFieldId, dataType) {
-  // Check if the URL already provides a Markdown URL. If it does, use that
-  // URL to load and render the Markdown.
+function initializeDataUrl(dataFieldId, dataType, defaultDataUrl) {
+  // Check if the URL already provides a data URL. If it does, use that URL to
+  // load and render the data by type. Otherwise, use the provided default URL.
   const url = new URL(window.location);
-  renderDataUrl(url.searchParams.get(dataFieldId), dataFieldId, dataType);
+
+  let dataUrl = url.searchParams.get(dataFieldId);
+  if (dataUrl === null) {
+    dataUrl = defaultDataUrl;
+  }
+
+  renderDataUrl(dataUrl, dataFieldId, dataType);
 
   // Listen for changes to the URL from this field id.
   const dataField = d3.select("#" + dataFieldId)
@@ -243,8 +249,8 @@ window.addEventListener('DOMContentLoaded', (event) => {
 
       // Initialize URLs for user-provided data. Tries to find URLs in the
       // current app URL and listens for changes to the given text field ids.
-      initializeDataUrl("data-url", "csv");
-      initializeDataUrl("pdb-url", "pdb");
-      initializeDataUrl("markdown-url", "markdown");
+      initializeDataUrl("data-url", "csv", "/_data/IAV/flu_dms-view.csv");
+      initializeDataUrl("pdb-url", "pdb", "/_data/IAV/4O5N_trimer.pdb");
+      initializeDataUrl("markdown-url", "markdown", "/_data/IAV/lee2019mapping.md");
     });
 });

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -123,11 +123,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
           d3.select("#markdown-url").property('value'))
         );
 
-      var clearButton = d3.select("#line_plot")
-        .insert("button", "svg")
-        .text("clear selections")
-        .attr("id", "clearButton")
-        .classed("button", true)
+      var clearButton = d3.select("#clearButton")
         .on('click', clearbuttonchange);
 
       var conditiondropdown = d3.select("#line_plot")

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -185,7 +185,7 @@ function renderDataUrl (dataUrl, dataFieldId, dataType) {
     // document's URL.
     const url = new URL(window.location);
     url.searchParams.set(dataFieldId, dataUrl);
-    history.replaceState({}, "", url.toString());
+    history.pushState({}, "", url.toString());
     console.log("Changed URL to: " + url.toString());
 
     // Update the URL text field to reflect the provided value.

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -6,19 +6,208 @@
 var chart;
 var perSiteData;
 var logoplot;
-var dataPath = "_data/IAV/flu_dms-view.csv";
-var proteinPath = "_data/IAV/4O5N_trimer.pdb";
+
+let conditiondropdown;
+let sitedropdown;
+let mutdropdown;
 
 var dropdownChange;
 var clearbuttonchange;
 
-var protein;
-var greyColor = "#999999";
+let protein;
+const greyColor = "#999999";
 
 // Bitstream Vera Fonts provided by Gnome:
 // https://www.gnome.org/fonts/
 var fontPath = "_data/fonts/DejaVuSansMonoBold_SeqLogo.ttf";
 var fontObject;
+
+// Define functions to load and render data URLs including Markdown, CSV, and
+// PDB files.
+
+function renderMarkdown (data) {
+  // Render Markdown text to HTML.
+  const markdownOutput = marked(data);
+
+  // If there is any rendered output, update the DOM.
+  if (markdownOutput.length > 0) {
+    d3.select("#markdown-output")
+      .html(markdownOutput);
+  }
+}
+
+function renderCsv(data) {
+  // Sort data by site
+  data.forEach(function(d) {
+    d.site = +d.site;
+    return d;
+  })
+  data = data.sort(function(a, b) {
+    return a.site - b.site;
+  });
+
+  d3.select("#line_plot")
+    .data([data])
+    .call(chart);
+
+  console.log(chart.data)
+  let conditions = Array.from(chart.data.keys());
+  console.log("conditions:");
+  console.log(conditions);
+  let site_metrics = Array.from(chart.data.get(conditions[0]).keys());
+  let mut_metrics = Array.from(chart.mutData.get(conditions[0]).keys());
+
+  var clearButton = d3.select("#clearButton")
+    .on('click', clearbuttonchange);
+
+  if (conditiondropdown === undefined) {
+    console.log("No condition dropdown exists yet.");
+    conditiondropdown = d3.select("#line_plot")
+      .insert("select", "svg")
+      .attr("id", 'condition')
+      .on("change", dropdownChange);
+  }
+  else {
+    console.log("Use existing condition dropdown.");
+  }
+
+  if (sitedropdown === undefined) {
+    sitedropdown = d3.select("#line_plot")
+      .insert("select", "svg")
+      .attr("id", 'site')
+      .on("change", dropdownChange);
+  }
+
+  conditiondropdown.selectAll("option")
+    .data(conditions)
+    .join("option")
+    .attr("value", function(d) {
+      return d;
+    })
+    .text(function(d) {
+      return d;
+    })
+
+  sitedropdown.selectAll("option")
+    .data(site_metrics)
+    .join("option")
+    .attr("value", function(d) {
+      return d;
+    })
+    .text(function(d) {
+      return d.substring(5, );
+    })
+
+  if (mutdropdown === undefined) {
+    mutdropdown = d3.select("#logo_plot")
+      .insert("select", "svg")
+      .attr("id", 'mutation_metric')
+      .on("change", dropdownChange);
+  }
+
+  mutdropdown.selectAll("option")
+    .data(mut_metrics)
+    .join("option")
+    .attr("value", function(d) {
+      return d;
+    })
+    .text(function(d) {
+      return d.substring(4, );
+    });
+
+  // Select the site with the maximum y value by default.
+  console.log("Select site with maximum y value");
+  var max_y_value = d3.max(Array.from(chart.condition_data.values()), d => +d.metric);
+  var max_y_record = Array.from(chart.condition_data.values()).filter(d => +d.metric == max_y_value);
+
+  if (max_y_record.length > 0) {
+    console.log("click site " + max_y_record[0].site);
+    d3.select("#site_" + max_y_record[0].site).dispatch("click");
+  }
+}
+
+function renderPdb(data) {
+  protein = data;
+  protein.setRotation([2, 0, 0])
+  protein.autoView()
+  protein.addRepresentation(polymerSelect.value, {
+    sele: "polymer",
+    name: "polymer",
+    color: greyColor
+  });
+
+  return protein;
+}
+
+function renderDataUrl (dataUrl, dataFieldId, dataType) {
+  // Try to load data from the user's provided URL and render it based on the
+  // provided data type. If the URL is null, then it wasn't defined in the app
+  // URL, so we don't attempt to render it.
+  if (dataUrl === null || dataUrl.length === 0) {
+    return;
+  }
+
+  let dataFunction;
+  let renderFunction;
+
+  if (dataType === "markdown") {
+    dataFunction = d3.text;
+    renderFunction = renderMarkdown;
+  }
+  else if (dataType === "csv") {
+    dataFunction = d3.csv;
+    renderFunction = renderCsv;
+  }
+  else if (dataType === "pdb") {
+    dataFunction = (d) => {
+      stage.removeAllComponents();
+      return stage.loadFile(d)
+    };
+    renderFunction = renderPdb;
+  }
+  else {
+    console.log("Unsupported data type: " + dataType);
+    return;
+  }
+
+  dataFunction(dataUrl).then(data => {
+    // Render the given markdown.
+    renderFunction(data);
+
+    // Remove any invalid input status for the URL text field.
+    d3.select("#" + dataFieldId).classed('is-invalid', false);
+
+    // Update the document's query string to reflect the requested URL.
+    // This should help maintain state if the user copies and pastes the
+    // document's URL.
+    const url = new URL(window.location);
+    url.searchParams.set(dataFieldId, dataUrl);
+    history.replaceState({}, "", url.toString());
+    console.log("Changed URL to: " + url.toString());
+
+    // Update the URL text field to reflect the provided value.
+    d3.select("#" + dataFieldId).property('value', dataUrl);
+  }).catch(reason => {
+    // Let the user know their URL could not be loaded.
+    console.log("Failed to load data: " + reason);
+    d3.select("#" + dataFieldId).classed('is-invalid', true);
+  });
+}
+
+function initializeDataUrl(dataFieldId, dataType) {
+  // Check if the URL already provides a Markdown URL. If it does, use that
+  // URL to load and render the Markdown.
+  const url = new URL(window.location);
+  renderDataUrl(url.searchParams.get(dataFieldId), dataFieldId, dataType);
+
+  // Listen for changes to the URL from this field id.
+  const dataField = d3.select("#" + dataFieldId)
+    .on("change", () => renderDataUrl(
+      d3.select("#" + dataFieldId).property('value'),
+      dataFieldId,
+      dataType
+    ));
+}
 
 window.addEventListener('DOMContentLoaded', (event) => {
   console.log('DOM fully loaded and parsed');
@@ -32,25 +221,6 @@ window.addEventListener('DOMContentLoaded', (event) => {
   // Initialize the mutation/site chart.
   logoplot = logoplotChart("#logo_plot");
 
-  // Request data for charts.
-  var promise1 = d3.csv(dataPath).then(function(data) {
-    // Sort data by site
-    data.forEach(function(d) {
-      d.site = +d.site;
-      return d;
-    })
-    data = data.sort(function(a, b) {
-      return a.site - b.site;
-    });
-
-    d3.select("#line_plot")
-      .data([data])
-      .call(chart)
-  });
-
-  // TODO: rename promise variable
-  var promise3 = loadStructure(proteinPath);
-
   var promiseFontLoaded = opentype.load(fontPath, function(err, font) {
     if (err) {
       console.log("Font could not be loaded: " + err);
@@ -63,122 +233,14 @@ window.addEventListener('DOMContentLoaded', (event) => {
   // Wait for all data to load before initializing content across the entire
   // application.
   console.log("Waiting for promises...");
-  Promise.all([promise1, promise3, promiseFontLoaded]).then(
+  Promise.all([promiseFontLoaded]).then(
     values => {
       console.log("Promises fulfilled!");
-      console.log(values);
 
-      console.log(chart.data)
-      conditions = Array.from(chart.data.keys());
-      site_metrics = Array.from(chart.data.get(conditions[0]).keys());
-      mut_metrics = Array.from(chart.mutData.get(conditions[0]).keys());
-
-      function renderMarkdown (data) {
-        // Render Markdown text to HTML.
-        const markdownOutput = marked(data);
-
-        // If there is any rendered output, update the DOM.
-        if (markdownOutput.length > 0) {
-          d3.select("#markdown-output")
-            .html(markdownOutput);
-        }
-      }
-
-      // Check if the URL already provides a Markdown URL. If it does, use that
-      // URL to load and render the Markdown.
-      const url = new URL(window.location);
-      const markdownUrl = url.searchParams.get("markdown-url");
-      if (markdownUrl !== null) {
-        renderMarkdownUrl(markdownUrl);
-
-        // Update the Markdown URL text field to reflect the provided value.
-        d3.select("#markdown-url").property('value', markdownUrl);
-      }
-
-      function renderMarkdownUrl (markdownUrl) {
-        // Try to load the user's provided URL to a Markdown document.
-        if (markdownUrl.length > 0) {
-          d3.text(markdownUrl).then(data => {
-            // Render the given markdown.
-            renderMarkdown(data);
-
-            // Remove any invalid input status for the URL text field.
-            d3.select("#markdown-url").classed('is-invalid', false);
-
-            // Update the document's query string to reflect the requested URL.
-            // This should help maintain state if the user copies and pastes the
-            // document's URL.
-            const url = new URL(window.location);
-            url.searchParams.set("markdown-url", markdownUrl);
-            history.replaceState({}, "", url.toString());
-          }).catch(reason => {
-            // Let the user know their URL could not be loaded.
-            d3.select("#markdown-url").classed('is-invalid', true);
-          });
-        }
-      }
-
-      var markdownField = d3.select("#markdown-url")
-        .on("change", () => renderMarkdownUrl(
-          d3.select("#markdown-url").property('value'))
-        );
-
-      var clearButton = d3.select("#clearButton")
-        .on('click', clearbuttonchange);
-
-      var conditiondropdown = d3.select("#line_plot")
-        .insert("select", "svg")
-        .attr("id", 'condition')
-        .on("change", dropdownChange);
-
-      var sitedropdown = d3.select("#line_plot")
-        .insert("select", "svg")
-        .attr("id", 'site')
-        .on("change", dropdownChange);
-
-      conditiondropdown.selectAll("option")
-        .data(conditions)
-        .enter().append("option")
-        .attr("value", function(d) {
-          return d;
-        })
-        .text(function(d) {
-          return d;
-        })
-
-      sitedropdown.selectAll("option")
-        .data(site_metrics)
-        .enter().append("option")
-        .attr("value", function(d) {
-          return d;
-        })
-        .text(function(d) {
-          return d.substring(5, );
-        })
-
-      var mutdropdown = d3.select("#logo_plot")
-        .insert("select", "svg")
-        .attr("id", 'mutation_metric')
-        .on("change", dropdownChange);
-
-      mutdropdown.selectAll("option")
-        .data(mut_metrics)
-        .enter().append("option")
-        .attr("value", function(d) {
-          return d;
-        })
-        .text(function(d) {
-          return d.substring(4, );
-        });
-
-      // Select the site with the maximum y value by default.
-      console.log("Select site with maximum y value");
-      var max_y_value = d3.max(Array.from(chart.condition_data.values()), d => +d.metric);
-      var max_y_record = Array.from(chart.condition_data.values()).filter(d => +d.metric == max_y_value);
-
-      if (max_y_record.length > 0) {
-        console.log("click site " + max_y_record[0].site);
-        d3.select("#site_" + max_y_record[0].site).dispatch("click");
-      }
+      // Initialize URLs for user-provided data. Tries to find URLs in the
+      // current app URL and listens for changes to the given text field ids.
+      initializeDataUrl("data-url", "csv");
+      initializeDataUrl("pdb-url", "pdb");
+      initializeDataUrl("markdown-url", "markdown");
     });
 });

--- a/docs/_javascript/prot_struct.js
+++ b/docs/_javascript/prot_struct.js
@@ -1,9 +1,7 @@
 // Code for example: interactive/simple-viewer
-var protein;
-var greyColor = "#999999";
 
 // Create NGL Stage object
-var stage = new NGL.Stage("protein");
+const stage = new NGL.Stage("protein");
 stage.setParameters({
   backgroundColor: "white"
 });
@@ -116,7 +114,7 @@ var polymerSelect = createSelect([
 })
 
 // tooltip setup
-tooltip = createElement("div", {}, {
+const tooltip = createElement("div", {}, {
   display: "none",
   position: "absolute",
   zIndex: 10,

--- a/docs/_javascript/prot_struct.js
+++ b/docs/_javascript/prot_struct.js
@@ -40,22 +40,6 @@ function createSelect(options, properties, style) {
   return select
 }
 
-// main function
-function loadStructure(input) {
-  stage.removeAllComponents()
-  return stage.loadFile(input).then(function(o) {
-    protein = o;
-    protein.setRotation([2, 0, 0])
-    protein.autoView()
-    protein.addRepresentation(polymerSelect.value, {
-      sele: "polymer",
-      name: "polymer",
-      color: greyColor
-    });
-    return protein;
-  })
-}
-
 // color a site by a certain color
 function selectSiteOnProtein(siteString, color) {
   // highlighted site representation should match main representation except

--- a/docs/h3n2_markdown.md
+++ b/docs/h3n2_markdown.md
@@ -1,0 +1,6 @@
+# Mapping Influenza Virus Escape from Human Sera
+
+## Mutational Antigenic Profiling experiment
+
+Lee  <span style="font-style:italic">et al.</span>, 2019 mapped how all amino-acid mutations to a Influenza Virus surface protein affected the virus's ability to escape serum from different humans.
+"Escape mutations" are defined as those mutations which are enriched, or positively differentially selected, in a cell-passage selection with serum compared to a mock cell-passage selection without serum.

--- a/docs/h3n2_markdown.md
+++ b/docs/h3n2_markdown.md
@@ -1,6 +1,4 @@
-# Mapping Influenza Virus Escape from Human Sera
-
-## Mutational Antigenic Profiling experiment
+## Mapping Influenza Virus Escape from Human Sera
 
 Lee  <span style="font-style:italic">et al.</span>, 2019 mapped how all amino-acid mutations to a Influenza Virus surface protein affected the virus's ability to escape serum from different humans.
 "Escape mutations" are defined as those mutations which are enriched, or positively differentially selected, in a cell-passage selection with serum compared to a mock cell-passage selection without serum.

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-legend/2.25.6/d3-legend.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/opentype.js@latest/dist/opentype.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -20,14 +21,18 @@
   <div class="container">
     <div class="row mt-3">
       <div class="col-12">
-        <h1>Mapping Influenza Virus Escape from Human Sera</h1>
-        <h4>Mutational Antigenic Profiling experiment:</h4>
-        Lee  <span style="font-style:italic">et al.</span>, 2019 mapped how all amino-acid mutations to a Influenza Virus surface protein affected the virus's ability to escape serum from different humans.
-        "Escape mutations" are defined as those mutations which are enriched, or positively differentially selected, in a cell-passage selection with serum compared to a mock cell-passage selection without serum.
+        <h1>DMS View</h1>
         <h4>Instructions:</h4>
         Select points of interest by <span style="font-weight:bold">clicking</span> or <span style="font-weight:bold">brushing</span> (click, hold and swipe).
         Deselect points by <span style="font-weight:bold">clicking</span> again or <span style="font-weight:bold">brushing</span> while holding down the <span style="font-style:italic">shift key</span> or after changing the radio button from <span style="font-style:italic">select</span> to <span style="font-style:italic">deselect</span>.
-        Change between different <span style="font-style:italic">conditions</span>, different <span style="font-style:italic">site-level metrics</span>, different <span style="font-style:italic">mutation-level metrics</span> and different <span style="font-style:italic">protein-representations</span> using the dropwdown menus.
+        Change between different <span style="font-style:italic">conditions</span>, different <span style="font-style:italic">site-level metrics</span>, different <span style="font-style:italic">mutation-level metrics</span> and different <span style="font-style:italic">protein-representations</span> using the dropdown menus.
+
+        <p>
+          <form>
+            <input id="markdown-url" text="text" class="form-control" placeholder="markdown URL" />
+            <input id="markdown-url-submit" class="btn btn-default" type="button" value="Submit">
+          </form>
+        </p>
       </div>
     </div>
 
@@ -43,6 +48,8 @@
         <div id="protein" style="width:400px; height:800px;"></div>
       </div>
     </div>
+    <div id="markdown-output"></div>
+
     <div class="footer-copyright text-center py-3">
       <a href="https://thenounproject.com/search/?q=eraser&creator=1997209&i=1144641">eraser</a> by Setyo Ari Wibowo from <a href="https://thenounproject.com/">The Noun Project</a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,13 +26,6 @@
         Select points of interest by <span style="font-weight:bold">clicking</span> or <span style="font-weight:bold">brushing</span> (click, hold and swipe).
         Deselect points by <span style="font-weight:bold">clicking</span> again or <span style="font-weight:bold">brushing</span> while holding down the <span style="font-style:italic">shift key</span> or after changing the radio button from <span style="font-style:italic">select</span> to <span style="font-style:italic">deselect</span>.
         Change between different <span style="font-style:italic">conditions</span>, different <span style="font-style:italic">site-level metrics</span>, different <span style="font-style:italic">mutation-level metrics</span> and different <span style="font-style:italic">protein-representations</span> using the dropdown menus.
-
-        <p>
-          <form>
-            <input id="markdown-url" text="text" class="form-control" placeholder="markdown URL" />
-            <input id="markdown-url-submit" class="btn btn-default" type="button" value="Submit">
-          </form>
-        </p>
       </div>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,10 +54,10 @@
       </div>
     </div>
 
-    <footer class="footer-copyright bg-light text-center p-3 mt-4 mb-4">
-      <div class="row">
-        Copyright 2020 by Sarah Hilton and John Huddleston.
-        <a href="https://thenounproject.com/search/?q=eraser&creator=1997209&i=1144641">Eraser icon</a> by Setyo Ari Wibowo from <a href="https://thenounproject.com/">The Noun Project</a>
+    <footer class="footer-copyright bg-light text-center pl-3 mt-4 mb-4">
+      <div class="row p-3 mb-0">
+        <span>Copyright 2020 by Sarah Hilton and John Huddleston.
+        <a href="https://thenounproject.com/search/?q=eraser&creator=1997209&i=1144641">Eraser icon</a> by Setyo Ari Wibowo from <a href="https://thenounproject.com/">The Noun Project</a></span>
       </div>
     </footer>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,6 +42,7 @@
         <p>
           <input type='radio' id="select" name="mode" value="select" checked /> select
           <input type='radio' id="deselect" name="mode" value="deselect" /> deselect
+          <button id="clearButton" class="button">clear selections</button>
         </p>
 
         <div id="line_plot" class="row"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,21 +38,34 @@
 
     <div class="row mb-5 border-top border-bottom pt-3 pb-3">
       <div class="col-8">
-        <h4 align="center">site-level metric</h4>
-        <input type='radio' id="select" name="mode" value="select" checked /> select
-        <input type='radio' id="deselect" name="mode" value="deselect" /> deselect
+        <p><input id="data-url" text="text" class="form-control" placeholder="Data URL" /></p>
+        <p>
+          <input type='radio' id="select" name="mode" value="select" checked /> select
+          <input type='radio' id="deselect" name="mode" value="deselect" /> deselect
+        </p>
+
         <div id="line_plot" class="row"></div>
         <div id="logo_plot" class="row"></div>
       </div>
       <div class="col-4">
-        <div id="protein" style="width:400px; height:800px;"></div>
+        <p><input id="pdb-url" text="text" class="form-control" placeholder="PDB URL" /></p>
+        <div id="protein" style="width: 400px; height: 550px;"></div>
       </div>
     </div>
-    <div id="markdown-output"></div>
 
-    <div class="footer-copyright text-center py-3">
-      <a href="https://thenounproject.com/search/?q=eraser&creator=1997209&i=1144641">eraser</a> by Setyo Ari Wibowo from <a href="https://thenounproject.com/">The Noun Project</a>
+    <div id="description" class="row mt-3">
+      <div class="col-12">
+        <p><input id="markdown-url" text="text" class="form-control" placeholder="markdown URL" /></p>
+        <div id="markdown-output"></div>
+      </div>
     </div>
+
+    <footer class="footer-copyright bg-light text-center p-3 mt-4 mb-4">
+      <div class="row">
+        Copyright 2020 by Sarah Hilton and John Huddleston.
+        <a href="https://thenounproject.com/search/?q=eraser&creator=1997209&i=1144641">Eraser icon</a> by Setyo Ari Wibowo from <a href="https://thenounproject.com/">The Noun Project</a>
+      </div>
+    </footer>
   </div>
   <script src="_javascript/main.js"></script>
   <script src="_javascript/line_plot_zoom.js" type="text/javascript"></script>


### PR DESCRIPTION
This PR allows users to specify their own data files through the DMS view interface, replacing the original hardcoded data paths. If no data files are specified by the user (the default), Juhye's data from Lee et al. 2019 Fig 3 are loaded.

In addition to the original site/mut plot and protein view, this PR also adds a section at the bottom of the page where users can provide a URL linking to a description of their data in Markdown format.

This PR closes #3, #87, #101, and #102.