### PR TITLE
Track the URL for data displayed in the site plot

### DIFF
--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -25,7 +25,7 @@ var fontObject;
 // Define functions to load and render data URLs including Markdown, CSV, and
 // PDB files.
 
-function renderMarkdown (data) {
+function renderMarkdown (data, dataUrl) {
   // Render Markdown text to HTML.
   const markdownOutput = marked(data);
 
@@ -36,10 +36,11 @@ function renderMarkdown (data) {
   }
 }
 
-function renderCsv(data) {
+function renderCsv(data, dataUrl) {
   // Sort data by site
   data.forEach(function(d) {
     d.site = +d.site;
+    d.data_url = dataUrl;
     return d;
   })
   data = data.sort(function(a, b) {
@@ -121,7 +122,7 @@ function renderCsv(data) {
   chart.updateLogoPlot();
 }
 
-function renderPdb(data) {
+function renderPdb(data, dataUrl) {
   protein = data;
   protein.setRotation([2, 0, 0])
   protein.autoView()
@@ -176,7 +177,7 @@ function renderDataUrl (dataUrl, dataFieldId, dataType) {
 
   dataFunction(dataUrl).then(data => {
     // Render the given markdown.
-    renderFunction(data);
+    renderFunction(data, dataUrl);
 
     // Remove any invalid input status for the URL text field.
     d3.select("#" + dataFieldId).classed('is-invalid', false);


### PR DESCRIPTION
Fixes a bug associated with running a d3 join based on the default key of the
array index where switching from a dataset with more sites to a dataset with
fewer caused the site plot to show circles in the wrong x axis position.

This commit adds a "data_url" entry to each data record and tracks the URL of
the currently loaded dataset. This information is used to generate an id for
each record going into the d3 join where the id is the data URL plus the site
id. When a new dataset is loaded, the data URL is updated and the d3 join
performs enter/exit operations instead of the update operation it was previously
using. One side effect of this approach is that selected sites are also cleared
when a new dataset is loaded.

This commit includes a related change that clears the brush in the context view
when switching datasets. This clearing prevents previously zoomed in views from
appearing to be broken when the focus view updates.

Closes #118.