### PR TITLE
Improve tooltip interactions and content

### DIFF
--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -137,7 +137,7 @@ function genomeLineChart() {
       .style("left", (d3.event.pageX + 10) + "px")
       .style("top", (d3.event.pageY + 10) + "px")
       .html("Site: " + d.label_site + "<br/>"  +
-        d.metric_name + ": " + parseFloat(d.metric).toFixed(2) + " <br/> " +
+        d.metric_name.substring(5,) + ": " + parseFloat(d.metric).toFixed(2) + " <br/> " +
         "Wildtype: " + d.wildtype)
   }
 

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -115,8 +115,9 @@ function genomeLineChart() {
     .call(brushFocus);
 
   // Create the base tooltip object.
-  const tooltip = d3.select(svgId)
+  const tooltip = d3.select("body")
     .append("div")
+    .attr("id", "tooltip-for-site-plot")
     .style("font-family", "'Open Sans', sans-serif")
     .style("text-align", "left")
     .style("position", "absolute")
@@ -129,13 +130,12 @@ function genomeLineChart() {
     .style("visibility", "hidden");
 
   function showTooltip(d) {
-    mousePosition = d3.mouse(d3.event.target);
     d3.select(this).classed("hovered", true);
 
     return tooltip
       .style("visibility", "visible")
-      .style("left", mousePosition[0] + "px")
-      .style("top", mousePosition[1] + 50 + "px")
+      .style("left", (d3.event.pageX + 10) + "px")
+      .style("top", (d3.event.pageY + 10) + "px")
       .html("Site: " + d.label_site + "<br/>"  +
         d.metric_name + ": " + parseFloat(d.metric).toFixed(2) + " <br/> " +
         "Wildtype: " + d.wildtype)

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -136,9 +136,9 @@ function genomeLineChart() {
       .style("visibility", "visible")
       .style("left", mousePosition[0] + "px")
       .style("top", mousePosition[1] + 50 + "px")
-      .html("Site: (" + d.protein_chain.join(" ") + ")" + d.protein_site + " <br/> " +
+      .html("Site: " + d.label_site + "<br/>"  +
         d.metric_name + ": " + parseFloat(d.metric).toFixed(2) + " <br/> " +
-        "seq number: " + d.site)
+        "Wildtype: " + d.wildtype)
   }
 
   function hideTooltip(d) {

--- a/docs/_javascript/logoplot.js
+++ b/docs/_javascript/logoplot.js
@@ -190,7 +190,8 @@ function logoplotChart(selection) {
           .style("visibility", "visible")
           .style("left", mousePosition[0] + "px")
           .style("top", mousePosition[1] + 400 + "px")
-          .html(d.mutation + ": " + round(d.metric, 2));
+          .html("Site: " + d.label_site + "<br/>"  +
+                d.mutation + ": " + round(d.metric, 2))
       }
 
       function hideTooltip(d) {

--- a/docs/_javascript/logoplot.js
+++ b/docs/_javascript/logoplot.js
@@ -164,8 +164,9 @@ function logoplotChart(selection) {
       svg.select(".y-axis").call(yAxis);
 
       // Create the base tooltip object.
-      const logoTooltip = d3.select("#logo_plot")
+      const logoTooltip = d3.select("body")
         .append("div")
+        .attr("id", "tooltip-for-logo-plot")
         .style("font-family", "'Open Sans', sans-serif")
         .style("text-align", "left")
         .style("position", "absolute")
@@ -183,13 +184,12 @@ function logoplotChart(selection) {
       }
 
       function showTooltip(d) {
-        mousePosition = d3.mouse(d3.event.target);
         d3.select(this).classed("hovered", true);
 
         return logoTooltip
           .style("visibility", "visible")
-          .style("left", mousePosition[0] + "px")
-          .style("top", mousePosition[1] + 400 + "px")
+          .style("left", (d3.event.pageX + 10) + "px")
+          .style("top", (d3.event.pageY + 10) + "px")
           .html("Site: " + d.label_site + "<br/>"  +
                 d.mutation + ": " + round(d.metric, 2))
       }

--- a/docs/_javascript/prot_struct.js
+++ b/docs/_javascript/prot_struct.js
@@ -114,11 +114,6 @@ stage.viewer.container.appendChild(tooltip);
 // remove default hoverPick mouse action
 // this appears to remve the default tooltip behavior
 stage.mouseControls.remove("hoverPick")
-nan_data = {
-  "site": NaN,
-  "label_site": NaN,
-  "wildtype": NaN
-}
 
 // listen to `hovered` signal to move tooltip around and change its text
 stage.signals.hovered.add(function(pickingProxy) {
@@ -137,24 +132,23 @@ stage.signals.hovered.add(function(pickingProxy) {
     } catch (err) {
       console.log(err)
     }
-    // if there are no entries ues NaN data
+    // if there are no entries, don't display tooltip
     if (residue_data.length == 0) {
-      residue_data = nan_data
+      tooltip.style.display = "none";
     } else {
       residue_data = residue_data[0]
+      // write to the tooltip
+      tooltip.innerHTML =
+        `Atom: ${chain_name} ${site_name}
+         <hr/>
+         Site: ${residue_data.label_site}<br/>
+         ${residue_data.metric_name.substring(5,)}: ${parseFloat(residue_data.metric).toFixed(2)}
+         Wildtype: ${residue_data.wildtype}<br/>
+         `
+      tooltip.style.bottom = cp.y + 3 + "px";
+      tooltip.style.left = cp.x + 3 + "px";
+      tooltip.style.display = "block";
     }
-
-    // write to the tooltip
-    tooltip.innerHTML =
-      `Atom: ${chain_name} ${site_name}
-       <hr/>
-       site: ${residue_data.site}<br/>
-       site label: ${residue_data.label_site}<br/>
-       wildtype: ${residue_data.wildtype}<br/>
-       `
-    tooltip.style.bottom = cp.y + 3 + "px";
-    tooltip.style.left = cp.x + 3 + "px";
-    tooltip.style.display = "block";
   } else {
     tooltip.style.display = "none";
   }


### PR DESCRIPTION
Display more relevant information in all tooltips including the site plot, logo plots, and protein view. Also, fix interaction bugs with site plot tooltips such that they always display as expected and do not interfere with clicking on site points. 

Closes #110 and closes #112.