### PR TITLE
Track application state in URL

### DIFF
--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -484,6 +484,9 @@ function genomeLineChart() {
         chart.condition_mut_data = chart.mutData.get(current_condition).get(current_mut_metric);
         updateChart(chart.condition_data);
         updateLogoPlot();
+
+        // Update URL to reflect dropdown values.
+        updateUrlFromFieldIds(dropdownsToTrack);
       };
 
       function updateChart(dataMap) {
@@ -581,10 +584,6 @@ function genomeLineChart() {
         // clear the physical brush (classification as 'brushed' remains)
         focus.select(".brush,.brush_select,.brush_deselect").call(brushFocus.move, null);
       }; // end of update chart
-      chart.condition_data = chart.data.get(conditions[0]).get(site_metrics[0]);
-      chart.condition_mut_data = chart.mutData.get(conditions[0]).get(mut_metrics[0]);
-
-      updateChart(chart.condition_data);
     }); // end of for each for the selection
   } // end of selection
 

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -477,7 +477,7 @@ function genomeLineChart() {
       // Handler for dropdown value change
       dropdownChange = function() {
         current_condition = d3.select("#condition").property('value');
-        current_site = d3.select("#site").property('value');
+        current_site = d3.select("#site_metric").property('value');
         current_mut_metric = d3.select("#mutation_metric").property('value');
 
         chart.condition_data = chart.data.get(current_condition).get(current_site);

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -250,12 +250,13 @@ function genomeLineChart() {
   function clickOnPoint(d) {
     // update FOCUS and PROTEIN
     if (!d3.select(this).classed("selected")) {
-      selectSite(d3.select(this))
-    }else {
-      deselectSite(d3.select(this))
+      // Select the current site.
+      updateSites([d3.select(this)]);
     }
-    // update the LOGOPLOT
-    updateLogoPlot();
+    else {
+      // Deselect the current site.
+      updateSites([], [d3.select(this)]);
+    }
   }
 
   var selectSite = function(circlePoint){
@@ -297,6 +298,30 @@ function genomeLineChart() {
       .data([chart.condition_mut_data.filter(d => chart.selectedSites.includes(d.site))])
       .call(logoplot);
     console.log("Selected sites: ", chart.selectedSites)
+  };
+
+  function updateSites(sitesToSelect, sitesToDeselect) {
+    let sitesUpdated = false;
+
+    // Select each individual site of those requested.
+    if (sitesToSelect !== undefined && sitesToSelect.length > 0) {
+      sitesToSelect.forEach(selectSite);
+      sitesUpdated = true;
+      console.log("Selected sites:", sitesToSelect);
+    }
+
+    // Deselect each individual site of those requested.
+    if (sitesToDeselect !== undefined && sitesToDeselect.length > 0) {
+      sitesToDeselect.forEach(deselectSite);
+      sitesUpdated = true;
+      console.log("Deselected sites:", sitesToDeselect);
+    }
+
+    // Update other panels to reflect new site selections. Do this once here to
+    // avoid repeating expensive calculations.
+    if (sitesUpdated) {
+      updateLogoPlot();
+    }
   };
 
   // determines if a point is in the brush or not
@@ -345,25 +370,23 @@ function genomeLineChart() {
       var selected = d3.selectAll(".selected").data().map(d => +d.site),
           brushed = d3.selectAll(".brushed").data().map(d => +d.site),
           targets;
+      let sitesToSelect = [];
+      let sitesToDeselect = [];
 
       // selection or deselection?
-      if(brushType === "select"){
+      if(brushType === "select") {
         targets = _.without.apply(_, [brushed].concat(selected));
-        targets.forEach(function(target) {
-          selectSite(d3.select("#site_" + target));
-        });
-
-      }else if(brushType === "deselect"){
-        targets = brushed.filter(value => selected.includes(value))
-        targets.forEach(function(target) {
-          deselectSite(d3.select("#site_" + target))
-        });
-
-      }else{
-        console.log('Unknown brush type')
+        sitesToSelect = targets.map(target => d3.select("#site_" + target));
+      }
+      else if(brushType === "deselect") {
+        targets = brushed.filter(value => selected.includes(value));
+        sitesToDeselect = targets.map(target => d3.select("#site_" + target));
+      }
+      else {
+        console.log('Unknown brush type');
       }
 
-      updateLogoPlot();
+      updateSites(sitesToSelect, sitesToDeselect);
       focus.select(".brush,.brush_select,.brush_deselect").call(brushFocus.move, null);
     }
   };
@@ -440,11 +463,8 @@ function genomeLineChart() {
 
       // Handler for clear button change
       clearbuttonchange = function() {
-        d3.selectAll(".selected").each(function(){
-          deselectSite(d3.select(this))
-        })
+        updateSites([], d3.selectAll(".selected").nodes().map(d => d3.select(d)));
 
-        updateLogoPlot();
         // clear the physical brush (classification as 'brushed' remains)
         focus.select(".brush,.brush_select,.brush_deselect").call(brushFocus.move, null);
       };
@@ -549,9 +569,8 @@ function genomeLineChart() {
               exit => exit.remove()
             );
 
-        d3.selectAll(".selected").each(function(){
-          selectSite(d3.select(this));
-        });
+        // Make sure all previously selected sites have been selected.
+        updateSites(d3.selectAll(".selected").nodes().map(d => d3.select(d)));
 
         // fix the axes (including labels)
         focus.select("#axis_y_focus")
@@ -619,8 +638,7 @@ function genomeLineChart() {
   };
 
   // Expose the function to select individual sites.
-  chart.selectSite = selectSite;
-  chart.updateLogoPlot = updateLogoPlot;
+  chart.updateSites = updateSites;
 
   return chart;
 } // end of genomeLineChart

--- a/docs/_javascript/line_plot_zoom.js
+++ b/docs/_javascript/line_plot_zoom.js
@@ -321,6 +321,12 @@ function genomeLineChart() {
     // avoid repeating expensive calculations.
     if (sitesUpdated) {
       updateLogoPlot();
+
+      d3.select("#selected_sites").property(
+        "value",
+        d3.selectAll(".selected").data().map(d => d.label_site).join(",")
+      );
+      updateUrlFromFieldIds(["selected_sites"]);
     }
   };
 

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -10,7 +10,7 @@ var logoplot;
 let conditiondropdown;
 let sitedropdown;
 let mutdropdown;
-const dropdownsToTrack = ["condition", "site", "mutation_metric"];
+const dropdownsToTrack = ["condition", "site_metric", "mutation_metric"];
 
 var dropdownChange;
 var clearbuttonchange;
@@ -118,7 +118,7 @@ function renderCsv(data, dataUrl) {
   if (sitedropdown === undefined) {
     sitedropdown = d3.select("#line_plot")
       .insert("select", "svg")
-      .attr("id", 'site')
+      .attr("id", 'site_metric')
       .on("change", dropdownChange);
   }
 

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -27,13 +27,26 @@ function updateStateFromUrl(fieldIds) {
   // Update the current value of the given field ids based on the corresponding
   // fields in the URL.
   const url = new URL(window.location);
+  let validOptions;
 
   fieldIds.forEach(field => {
     const fieldValue = url.searchParams.get(field);
 
     if (fieldValue !== null && fieldValue.length > 0) {
       console.log("Found field '" + field + "' in the URL with value: " + fieldValue);
-      d3.select("#" + field).property('value', fieldValue);
+
+      // Find the list of valid options for the current field.
+      validOptions = d3.select("#" + field).selectAll("option").nodes().map(d => d["value"]);
+
+      // Check whether the requested field value is valid.
+      // If it is, update the field.
+      // Otherwise, replace the URL field with the first valid option.
+      if (validOptions.includes(fieldValue)) {
+        d3.select("#" + field).property('value', fieldValue);
+      }
+      else {
+        console.log("WARNING:", fieldValue, "is not a validation option for the field", field);
+      }
     }
     else {
       console.log("Did not find field '" + field + "' in the URL.");

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -23,19 +23,22 @@ const greyColor = "#999999";
 var fontPath = "_data/fonts/DejaVuSansMonoBold_SeqLogo.ttf";
 var fontObject;
 
-function updateStateFromUrl(field) {
+function updateStateFromUrl(fieldIds) {
+  // Update the current value of the given field ids based on the corresponding
+  // fields in the URL.
   const url = new URL(window.location);
-  const fieldValue = url.searchParams.get(field);
 
-  if (fieldValue !== null && fieldValue.length > 0) {
-    console.log("Found field '" + field + "' in the URL with value: " + fieldValue);
+  fieldIds.forEach(field => {
+    const fieldValue = url.searchParams.get(field);
 
-    console.log(d3.select("#" + field));
-    d3.select("#" + field).property('value', fieldValue);
-  }
-  else {
-    console.log("Did not find field '" + field + "' in the URL.");
-  }
+    if (fieldValue !== null && fieldValue.length > 0) {
+      console.log("Found field '" + field + "' in the URL with value: " + fieldValue);
+      d3.select("#" + field).property('value', fieldValue);
+    }
+    else {
+      console.log("Did not find field '" + field + "' in the URL.");
+    }
+  });
 }
 
 function updateUrlFromFieldIds(fieldIds) {
@@ -145,7 +148,7 @@ function renderCsv(data, dataUrl) {
 
   // Initialize the state of each dropdown based on values in the URL.
   console.log("Initialize dropdowns from URL");
-  dropdownsToTrack.forEach(updateStateFromUrl);
+  updateStateFromUrl(dropdownsToTrack);
 
   // Update the chart from the current state of the dropdowns, after
   // initializing their state from the URL.

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -181,22 +181,33 @@ function renderCsv(data, dataUrl) {
   // Initialize the state of each dropdown based on values in the URL.
   console.log("Initialize dropdowns from URL");
   updateStateFromUrl(dropdownsToTrack).then(values => {
+    // Check whether the URL provides a non-empty list of selected sites. If
+    // not, we will select the maximum site by default.
+    const url = new URL(window.location);
+    let selectMaximumSite = true;
+    if (url.searchParams.get("selected_sites") !== null) {
+      selectMaximumSite = false;
+    }
+
     // Update the chart from the current state of the dropdowns, after
-    // initializing their state from the URL.
+    // initializing their state from the URL. This updates the URL to reflect
+    // the state of all tracked form fields.
     console.log(values);
     dropdownChange();
 
-    // Select the site with the maximum y value by default.
-    console.log("selected sites:", d3.select("#selected_sites").property("value"));
-    if (d3.select("#selected_sites").property("value").length > 0) {
-      selectedSitesChanged();
-    }
-    else {
+    // If the user does not provide any selected sites from the URL, select the
+    // site with the maximum y value by default.
+    if (selectMaximumSite) {
       console.log("Select site with maximum y value");
       const circles = d3.selectAll("circle");
       const maxMetricIndex = d3.maxIndex(circles.data(), d => +d.metric);
       const maxMetricRecord = d3.select(circles.nodes()[maxMetricIndex]);
       chart.updateSites([maxMetricRecord]);
+    }
+    else {
+      // If we are not selecting the maximum site in the data, select the
+      // user-provided sites. This can be an empty list.
+      selectedSitesChanged();
     }
   });
 }

--- a/docs/_javascript/main.js
+++ b/docs/_javascript/main.js
@@ -172,8 +172,7 @@ function renderCsv(data, dataUrl) {
   const circles = d3.selectAll("circle");
   const maxMetricIndex = d3.maxIndex(circles.data(), d => +d.metric);
   const maxMetricRecord = d3.select(circles.nodes()[maxMetricIndex]);
-  chart.selectSite(maxMetricRecord);
-  chart.updateLogoPlot();
+  chart.updateSites([maxMetricRecord]);
 }
 
 function renderPdb(data, dataUrl) {
@@ -189,9 +188,7 @@ function renderPdb(data, dataUrl) {
   // If data have been loaded into the site plot, select any sites from that
   // panel in the protein view, too.
   if (chart !== undefined) {
-    d3.selectAll(".selected").each(function(){
-      chart.selectSite(d3.select(this));
-    });
+    chart.updateSites(d3.selectAll(".selected").nodes().map(d => d3.select(d)));
   }
 
   return protein;

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,6 +35,7 @@
         <p>
           <input type='radio' id="select" name="mode" value="select" checked /> select
           <input type='radio' id="deselect" name="mode" value="deselect" /> deselect
+          <input id="selected_sites" text="text" class="form-control" style="display: inline; width: 50%" placeholder="Selected sites" />
           <button id="clearButton" class="button">clear selections</button>
         </p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,11 +31,11 @@
 
     <div class="row mb-5 border-top border-bottom pt-3 pb-3">
       <div class="col-8">
-        <p><input id="data-url" text="text" class="form-control" placeholder="Data URL" /></p>
+        <p><input id="data-url" text="text" class="form-control" placeholder="Data URL (relative or absolute paths allowed)" /></p>
         <p>
           <input type='radio' id="select" name="mode" value="select" checked /> select
           <input type='radio' id="deselect" name="mode" value="deselect" /> deselect
-          <input id="selected_sites" text="text" class="form-control" style="display: inline; width: 50%" placeholder="Selected sites" />
+          <input id="selected_sites" text="text" class="form-control" style="display: inline; width: 50%" placeholder="Selected sites (e.g., '144' or '144,160')" />
           <button id="clearButton" class="button">clear selections</button>
         </p>
 


### PR DESCRIPTION
Adds support for tracking the state of the application's dropdowns and selected sites in the URL. Also adds a form field where users can manually specify sites to select. This form field will track sites selected by other interactions as well (e.g., brushing).

Closes #4 
