### PR TITLE
clear selected sites when dataset changes

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ var chart;
 var perSiteData;
 var logoplot;
 
+let csvDataUrl;
 let conditiondropdown;
 let sitedropdown;
 let mutdropdown;
@@ -88,6 +89,20 @@ function renderMarkdown (data, dataUrl) {
 }
 
 function renderCsv(data, dataUrl) {
+  // When the data URL for the CSV changes, note that we want to reset the
+  // selected sites to the default instead of those in the current URL.
+  let resetSites = false;
+  if (csvDataUrl !== dataUrl) {
+    // Only reset sites if a CSV URL is defined already. Otherwise, we want to
+    // keep any sites provided in the URL.
+    if (csvDataUrl !== undefined) {
+      resetSites = true;
+    }
+
+    // Update the CSV data URL, so we can detect when it changes again later.
+    csvDataUrl = dataUrl;
+  }
+
   // Sort data by site
   data.forEach(function(d) {
     d.site = +d.site;
@@ -184,9 +199,20 @@ function renderCsv(data, dataUrl) {
     // Check whether the URL provides a non-empty list of selected sites. If
     // not, we will select the maximum site by default.
     const url = new URL(window.location);
-    let selectMaximumSite = true;
-    if (url.searchParams.get("selected_sites") !== null) {
+    let selectMaximumSite;
+
+    if (resetSites) {
+      // Clear all selected sites before we join new data from the new
+      // URL. Otherwise, we lose track of which sites were selected and cannot
+      // clear all panels.
+      selectMaximumSite = true;
+      clearbuttonchange();
+    }
+    else if (url.searchParams.get("selected_sites") !== null) {
       selectMaximumSite = false;
+    }
+    else {
+      selectMaximumSite = true;
     }
 
     // Update the chart from the current state of the dropdowns, after

--- a/main.js
+++ b/main.js
@@ -181,13 +181,7 @@ function renderCsv(data, dataUrl) {
   // Initialize the state of each dropdown based on values in the URL.
   console.log("Initialize dropdowns from URL");
   updateStateFromUrl(dropdownsToTrack).then(values => {
-    // Check whether the URL provides a non-empty list of selected sites. If
-    // not, we will select the maximum site by default.
     const url = new URL(window.location);
-    let selectMaximumSite = true;
-    if (url.searchParams.get("selected_sites") !== null) {
-      selectMaximumSite = false;
-    }
 
     // Update the chart from the current state of the dropdowns, after
     // initializing their state from the URL. This updates the URL to reflect
@@ -195,20 +189,13 @@ function renderCsv(data, dataUrl) {
     console.log(values);
     dropdownChange();
 
-    // If the user does not provide any selected sites from the URL, select the
-    // site with the maximum y value by default.
-    if (selectMaximumSite) {
+    // select the site with the maximum y value
       console.log("Select site with maximum y value");
+      clearbuttonchange()
       const circles = d3.selectAll("circle");
       const maxMetricIndex = d3.maxIndex(circles.data(), d => +d.metric);
       const maxMetricRecord = d3.select(circles.nodes()[maxMetricIndex]);
       chart.updateSites([maxMetricRecord]);
-    }
-    else {
-      // If we are not selecting the maximum site in the data, select the
-      // user-provided sites. This can be an empty list.
-      selectedSitesChanged();
-    }
   });
 }
 

--- a/main.js
+++ b/main.js
@@ -181,7 +181,13 @@ function renderCsv(data, dataUrl) {
   // Initialize the state of each dropdown based on values in the URL.
   console.log("Initialize dropdowns from URL");
   updateStateFromUrl(dropdownsToTrack).then(values => {
+    // Check whether the URL provides a non-empty list of selected sites. If
+    // not, we will select the maximum site by default.
     const url = new URL(window.location);
+    let selectMaximumSite = true;
+    if (url.searchParams.get("selected_sites") !== null) {
+      selectMaximumSite = false;
+    }
 
     // Update the chart from the current state of the dropdowns, after
     // initializing their state from the URL. This updates the URL to reflect
@@ -189,13 +195,20 @@ function renderCsv(data, dataUrl) {
     console.log(values);
     dropdownChange();
 
-    // select the site with the maximum y value
+    // If the user does not provide any selected sites from the URL, select the
+    // site with the maximum y value by default.
+    if (selectMaximumSite) {
       console.log("Select site with maximum y value");
-      clearbuttonchange()
       const circles = d3.selectAll("circle");
       const maxMetricIndex = d3.maxIndex(circles.data(), d => +d.metric);
       const maxMetricRecord = d3.select(circles.nodes()[maxMetricIndex]);
       chart.updateSites([maxMetricRecord]);
+    }
+    else {
+      // If we are not selecting the maximum site in the data, select the
+      // user-provided sites. This can be an empty list.
+      selectedSitesChanged();
+    }
   });
 }
 


### PR DESCRIPTION
Previously, when a new datafile was added the tool checked to see if there were selected sites in the URL or if not, selected the maximum y value in the new dataset.

Now, whenever a new dataset is added, the sites are cleared and the max y site is selected. This is because with the previous logic, because the flu human sera mapping is the default data, site 222 was always selected for every dataset. Now the assumption is new data means new y values so everything should reset. 

This closes #119 