### PR TITLE
polymer select dropdown menu is intialized in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,12 @@
       </div>
       <div class="col-4">
         <p><input id="pdb-url" text="text" class="form-control" placeholder="PDB URL" /></p>
+        <select name="polymerSelect">
+          <option value="cartoon">cartoon</option>
+          <option value="spacefill">spacefill</option>
+          <option value="licorice">sticks</option>
+          <option value="surface">surface</option>
+        </select>
         <div id="protein" style="width: 400px; height: 550px;"></div>
       </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -309,9 +309,6 @@ window.addEventListener('DOMContentLoaded', (event) => {
   // Initialize line chart.
   chart = genomeLineChart();
 
-  // Initialize protein view.
-  addElement(polymerSelect);
-
   // Initialize the mutation/site chart.
   logoplot = logoplotChart("#logo_plot");
 

--- a/prot_struct.js
+++ b/prot_struct.js
@@ -11,35 +11,6 @@ window.addEventListener("resize", function(event) {
   stage.handleResize();
 }, false);
 
-// add button to the screen
-function addElement(el) {
-  Object.assign(el.style, {
-    position: "absolute",
-    zIndex: 10
-  })
-  stage.viewer.container.appendChild(el)
-}
-
-// make button
-function createElement(name, properties, style) {
-  var el = document.createElement(name)
-  Object.assign(el, properties)
-  Object.assign(el.style, style)
-  return el
-}
-
-// button that selects certain parts of the protein
-function createSelect(options, properties, style) {
-  var select = createElement("select", properties, style)
-  options.forEach(function(d) {
-    select.add(createElement("option", {
-      value: d[0],
-      text: d[1]
-    }))
-  })
-  return select
-}
-
 // color a site by a certain color
 function selectSiteOnProtein(siteString, color) {
   // highlighted site representation should match main representation except
@@ -64,38 +35,29 @@ function deselectSiteOnProtein(siteString) {
   stage.getRepresentationsByName(siteString).dispose()
 }
 
-// select protein display type
-var polymerSelect = createSelect([
-  ["cartoon", "cartoon"],
-  ["spacefill", "spacefill"],
-  ["licorice", "sticks"],
-  ["surface", "surface"]
-], {
-  onchange: function(e) {
-    stage.getRepresentationsByName("polymer").dispose()
-    stage.eachComponent(function(o) {
-      o.addRepresentation(e.target.value, {
-          sele: "polymer",
-          name: "polymer",
-          color: greyColor
-        })
-        // on change, reselect the points so they are "on top"
-      d3.selectAll(".selected").data().forEach(function(element) {
-        element.protein_chain.forEach(function(chain){
-          deselectSiteOnProtein(":" + chain + " and " + element.protein_site)
-          selectSiteOnProtein(
-            ":" + chain + " and " + element.protein_site,
-            color_key[element.site]
-          )
-        })
+var polymerSelect = document.querySelector('select[name="polymerSelect"]');
 
-      });
-    })
-  }
-}, {
-  top: "36px",
-  left: "12px"
-})
+polymerSelect.addEventListener('change', function(e) {
+  stage.getRepresentationsByName("polymer").dispose()
+  stage.eachComponent(function(o) {
+    o.addRepresentation(e.target.value, {
+        sele: "polymer",
+        name: "polymer",
+        color: greyColor
+      })
+      // on change, reselect the points so they are "on top"
+    d3.selectAll(".selected").data().forEach(function(element) {
+      element.protein_chain.forEach(function(chain){
+        deselectSiteOnProtein(":" + chain + " and " + element.protein_site)
+        selectSiteOnProtein(
+          ":" + chain + " and " + element.protein_site,
+          color_key[element.site]
+        )
+      })
+
+    });
+  })
+});
 
 // tooltip setup
 const tooltip = createElement("div", {}, {


### PR DESCRIPTION
This PR changes how the polymer dropdown menu is initialized but shouldn't change any behavior. 

Previously, the polymer select menu was created by the protein structure script via many functions we took from an `ngl-viewer` gallery example. This worked well except that it was hard to control the exact placement. 

Now, this dropdown menu is created in the `index.html` but the change function is defined in the `prot_struct.js` script. This means that the dropdown menu plays much better with the other html elements. 