### PR TITLE
Do not interpolate data across gaps in the context panel

### DIFF
--- a/line_plot_zoom.js
+++ b/line_plot_zoom.js
@@ -49,7 +49,10 @@ function genomeLineChart() {
     xAxisContext = d3.axisBottom(xScaleContext),
     yAxis = d3.axisLeft(yScaleFocus),
     lineFocus = d3.line().x(XFocus).y(YFocus),
-    areaContext = d3.area().curve(d3.curveMonotoneX).x(XContext).y0(
+    areaContext = d3.area().defined(function(d){
+      console.log(d.site, d.metric===undefined, d.metric)
+      return !(d.metric===undefined);
+    }).x(XContext).y0(
       plotHeightContext).y1(YContext),
     brushContext = d3.brushX().extent([
       [0, 0],
@@ -269,12 +272,9 @@ function genomeLineChart() {
 
     // update the PROTEIN structure
     circleData.protein_chain.forEach(function(chain){
-      if(!missingData.includes(chain) &&
-         !missingData.includes(circleData.protein_site)){
-        selectSiteOnProtein(":" + chain + " and " +
-          circleData.protein_site,
-          color_key[circleData.site]);
-      }
+      selectSiteOnProtein(":" + chain + " and " +
+        circleData.protein_site,
+        color_key[circleData.site]);
     });
   };
 
@@ -459,7 +459,20 @@ function genomeLineChart() {
       });
       // Group data by condition and site and only takes the first of the sites,
       // to get site-level data.
-      chart.data = d3.rollup(long_data, v => v[0], d => d.condition, d => d.metric_name, d => d.site);
+      data = d3.rollup(long_data, v => v[0], d => d.condition, d => d.metric_name, d => d.site)
+      conditions.forEach(function(condition){
+        site_metrics.forEach(function(site_metric){
+          let sites = Array.from(data.get(condition).get(site_metric).keys()),
+              minSite = Math.min.apply(null, sites),
+              maxSite = Math.max.apply(null, sites),
+          fullRange = _.range(minSite, maxSite+1);
+          missing = _.without.apply(_, [fullRange].concat(sites));
+          missing.forEach(function(m){
+            data.get(condition).get(site_metric).set(m, {"condition": condition, "metric_name": site_metric, "metric": undefined, "label_site": undefined, "site":m})
+          })
+        })
+      })
+      chart.data = new Map([...data.entries()].sort());;
 
       // Group data by condition and mutation metric, keeping all records to get
       // site- and mutation-level data.
@@ -519,7 +532,7 @@ function genomeLineChart() {
       };
 
       function updateChart(dataMap) {
-        const data = Array.from(dataMap.values());
+        const data = Array.from(dataMap.values()).sort((a, b) => a.site - b.site);
 
         // Track the URL of the current dataset and use this information to
         // clear or reset elements of the chart that shouldn't be maintained
@@ -604,7 +617,7 @@ function genomeLineChart() {
 
         // Create the context plot excluding sites with missing data.
         context.selectAll("path.area")
-          .data([data.filter(d => d.metric !== undefined)])
+          .data([data])
           .join("path")
           .attr("class", "area")
           .attr("d", areaContext);


### PR DESCRIPTION
When data are missing for specific sites in a genome, the default area plot in
the genome context panel fills in the missing data by drawing lines between the
available data. This behavior gives the false impression that there are data
when there is actually a gap.

This PR resolves this issue by adding mock records to the long-form CSV data
for each of the gap sites and using d3 area's `defined` function [1] to only plot
area curves between data points that are defined in the original data set.

Resolves #108 

[1] https://github.com/d3/d3-shape/blob/master/README.md#area_defined