### PR TITLE
Add basic ability to download SVGs from D3 panels

### DIFF
--- a/data/download.svg
+++ b/data/download.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-download"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>

--- a/index.html
+++ b/index.html
@@ -56,8 +56,12 @@
           <button id="clearButton" class="button">clear selections</button>
         </p>
 
-        <div id="line_plot" class="row"></div>
-        <div id="logo_plot" class="row"></div>
+        <div id="line_plot" class="row">
+          <button id="line_plot_download" type="button" class="btn btn-light float-right"><img src="data/download.svg" /> Download SVG</button>
+        </div>
+        <div id="logo_plot" class="row">
+          <button id="logo_plot_download" type="button" class="btn btn-light float-right"><img src="data/download.svg" /> Download SVG</button>
+        </div>
       </div>
       <div class="col-4">
         <div class="alert alert-danger" role="alert" id="proteinFormFieldAlert" hidden>

--- a/index.html
+++ b/index.html
@@ -70,9 +70,9 @@
           <a href="https://dms-view.github.io/docs/dataupload/" target="_blank">documentation</a>.
         </div>
         <div class="row">
-          <input id="pdb-url" text="text" class="form-control" placeholder="PDB URL" />
+          <p><input id="pdb-url" text="text" class="form-control" placeholder="PDB URL" /></p>
         </div>
-        <div class="row mt-2 mb-2">
+        <div class="row mb-2">
           <select id="polymer-dropdown" name="polymerSelect" class="ml-0">
             <option value="cartoon">cartoon</option>
             <option value="spacefill">spacefill</option>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           <input type='radio' id="select" name="mode" value="select" checked /> select
           <input type='radio' id="deselect" name="mode" value="deselect" /> deselect
           <input id="selected_sites" text="text" class="form-control" style="display: inline; width: 50%" placeholder="Selected sites (e.g., '144' or '144,160')" />
-          <button id="clearButton" class="button">clear selections</button>
+          <button id="clearButton" type="button" class="btn btn-light">clear selections</button>
         </p>
 
         <div id="line_plot" class="row">
@@ -69,13 +69,18 @@
           Please review the URL below or check the contents of the protein structure by reviewing the
           <a href="https://dms-view.github.io/docs/dataupload/" target="_blank">documentation</a>.
         </div>
-        <p><input id="pdb-url" text="text" class="form-control" placeholder="PDB URL" /></p>
-        <select name="polymerSelect">
-          <option value="cartoon">cartoon</option>
-          <option value="spacefill">spacefill</option>
-          <option value="licorice">sticks</option>
-          <option value="surface">surface</option>
-        </select>
+        <div class="row">
+          <input id="pdb-url" text="text" class="form-control" placeholder="PDB URL" />
+        </div>
+        <div class="row mt-2 mb-2">
+          <select id="polymer-dropdown" name="polymerSelect" class="ml-0">
+            <option value="cartoon">cartoon</option>
+            <option value="spacefill">spacefill</option>
+            <option value="licorice">sticks</option>
+            <option value="surface">surface</option>
+          </select>
+          <button id="protein_plot_download" type="button" class="btn btn-light float-right"><img src="data/download.svg" /> Download PNG</button>
+        </div>
         <div id="protein" style="width: 400px; height: 550px;"></div>
       </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -24,6 +24,31 @@ const greyColor = "#999999";
 var fontPath = "/data/fonts/DejaVuSansMonoBold_SeqLogo.ttf";
 var fontObject;
 
+const downloadSVG = (elementId, filename) => {
+  // Download logic based on Curran Kelleher's example:
+  // http://bl.ocks.org/curran/7cf9967028259ea032e8
+
+  // Find the SVG element associated with the given panel element id.
+  const svg = document.getElementById(elementId).getElementsByTagName("svg")[0];
+
+  // Serialize the SVG element as XML.
+  const serializer = new XMLSerializer;
+  const svgAsXML = serializer.serializeToString(svg);
+
+  // Create a data URL with the SVG data embedded inside.
+  const svgDataURL = "data:image/svg+xml," + encodeURIComponent(svgAsXML);
+
+  // Prepare a link to download the data by inserting the link element into the
+  // DOM, clicking it, and removing it again.
+  // The following line makes the download work in Firefox.
+  const dl = document.createElement("a");
+  document.body.appendChild(dl);
+  dl.setAttribute("href", svgDataURL);
+  dl.setAttribute("download", filename);
+  dl.click();
+  document.body.removeChild(dl);
+};
+
 function updateStateFromUrl(fieldIds) {
   // Update the current value of the given field ids based on the corresponding
   // fields in the URL.
@@ -124,10 +149,16 @@ function renderCsv(data, dataUrl) {
   var clearButton = d3.select("#clearButton")
     .on('click', clearbuttonchange);
 
+  var linePlotDownloadButton = d3.select("#line_plot_download")
+      .on('click', function () { downloadSVG("line_plot", "line_plot.svg"); });
+
+  var logoPlotDownloadButton = d3.select("#logo_plot_download")
+      .on('click', function () { downloadSVG("logo_plot", "logo_plot.svg"); });
+
   if (conditiondropdown === undefined) {
     console.log("No condition dropdown exists yet.");
     conditiondropdown = d3.select("#line_plot")
-      .insert("select", "svg")
+      .insert("select", "button")
       .attr("id", 'condition')
       .on("change", dropdownChange);
   }
@@ -137,7 +168,7 @@ function renderCsv(data, dataUrl) {
 
   if (sitedropdown === undefined) {
     sitedropdown = d3.select("#line_plot")
-      .insert("select", "svg")
+      .insert("select", "button")
       .attr("id", 'site_metric')
       .on("change", dropdownChange);
   }
@@ -164,7 +195,7 @@ function renderCsv(data, dataUrl) {
 
   if (mutdropdown === undefined) {
     mutdropdown = d3.select("#logo_plot")
-      .insert("select", "svg")
+      .insert("select", "button")
       .attr("id", 'mutation_metric')
       .on("change", dropdownChange);
   }

--- a/main.js
+++ b/main.js
@@ -155,6 +155,21 @@ function renderCsv(data, dataUrl) {
   var logoPlotDownloadButton = d3.select("#logo_plot_download")
       .on('click', function () { downloadSVG("logo_plot", "logo_plot.svg"); });
 
+  var proteinPlotDownloadButton = d3.select("#protein_plot_download")
+      .on(
+        'click',
+        function () {
+          stage.makeImage({
+            factor: 4,
+            antialias: true,
+            trim: false,
+            transparent: false
+          }).then(function (blob) {
+            NGL.download(blob, "protein_plot.png");
+          });
+        }
+      );
+
   if (conditiondropdown === undefined) {
     console.log("No condition dropdown exists yet.");
     conditiondropdown = d3.select("#line_plot")

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+p {
+    width: 100%;
+}
+
 /* Styles for genome line chart. */
 .line {
   fill: none;


### PR DESCRIPTION
Adds download buttons to the line and logo plot panels and links these to a downloadSVG function that serializes the SVG XML of each panel and sends it to the user as a downloaded file. This commit does not add the ability to download the PDB panel. The PDB panel uses Canvas instead of SVG, so we need to use NGL's built-in mechanisms or another approach to support downloads.

Edit: Also adds download button to the protein plot panel linked to the NGL Viewer's `makeImage` function which exports a PNG.

Resolves #147.