### PR TITLE
Logoplot colors

### DIFF
--- a/line_plot_zoom.js
+++ b/line_plot_zoom.js
@@ -454,7 +454,7 @@ function genomeLineChart() {
         }
       });
 
-      if(Object.keys(alldata[0]).includes("colors_mutation")){
+      if(Object.keys(alldata[0]).includes("color_for_mutation")){
         var colorScheme = 'custom';
       }else{
         var colorScheme = 'functional';
@@ -490,7 +490,7 @@ function genomeLineChart() {
               "condition": row["condition"],
               "metric": +row[colname],
               "metric_name": colname,
-              "colors_mutation": row["colors_mutation"],
+              "color_for_mutation": row["color_for_mutation"],
               "color_scheme": colorScheme
             });
           }

--- a/line_plot_zoom.js
+++ b/line_plot_zoom.js
@@ -457,6 +457,12 @@ function genomeLineChart() {
         }
       });
 
+      if(Object.keys(alldata[0]).includes("colors_mutation")){
+        var colorScheme = 'custom';
+      }else{
+        var colorScheme = 'functional';
+      }
+
       var long_data = []
       var mut_long_data = [];
       alldata.forEach( function(row) {
@@ -486,7 +492,9 @@ function genomeLineChart() {
               "mutation": row["mutation"],
               "condition": row["condition"],
               "metric": +row[colname],
-              "metric_name": colname
+              "metric_name": colname,
+              "colors_mutation": row["colors_mutation"],
+              "color_scheme": colorScheme
             });
           }
         })

--- a/line_plot_zoom.js
+++ b/line_plot_zoom.js
@@ -444,14 +444,11 @@ function genomeLineChart() {
       conditions = conditions.filter((x, i, a) => a.indexOf(x) == i);
 
       var site_metrics = []
+      var mut_metrics = []
       Object.keys(alldata[0]).forEach(function(col){
         if (col.startsWith("site_")){
           site_metrics.push(col)
         }
-      });
-
-      var mut_metrics = []
-      Object.keys(alldata[0]).forEach(function(col){
         if (col.startsWith("mut_")){
           mut_metrics.push(col)
         }

--- a/logoplot.js
+++ b/logoplot.js
@@ -179,7 +179,9 @@ function logoplotChart(selection) {
       }
       else if(colorScheme == 'custom'){}
       else{
-        var colorMap = zScale;
+        dataToPlot.forEach(function(d){
+          d["colors_mutation"] = zScale[d["mutation"]]
+        })
       };
       svg.select(".x-axis").call(xAxis.tickFormat(function(site, i) {
         // Display a tick label for each site up to the maximum number of

--- a/logoplot.js
+++ b/logoplot.js
@@ -177,7 +177,13 @@ function logoplotChart(selection) {
           d["colors_mutation"] = functionalColors[d["mutation"]]
         })
       }
-      else if(colorScheme == 'custom'){}
+      else if(colorScheme == 'custom'){
+        dataToPlot.forEach(function(d){
+          if(d["colors_mutation"] == 'functional'){
+            d["colors_mutation"] = functionalColors[d["mutation"]]
+          }
+        })
+      }
       else{
         dataToPlot.forEach(function(d){
           d["colors_mutation"] = zScale[d["mutation"]]

--- a/logoplot.js
+++ b/logoplot.js
@@ -1,5 +1,5 @@
 function logoplotChart(selection) {
-  var colorScheme = 'functional';
+  var colorScheme = "functional";
   var divWidth = 760,
       divHeight = 250,
       margin = {top: 40, left: 40, bottom: 0, right: 0},
@@ -144,6 +144,9 @@ function logoplotChart(selection) {
       ]).nice();
 
       // Calculate the color domain.
+      if(dataToPlot[0]){
+        colorScheme =  dataToPlot[0].color_scheme
+      }
       zScale.range(d3.quantize(t => d3.interpolateSpectral(t * 0.8 + 0.1), mutations.length).reverse())
         .unknown("#cccccc");
       var functionalColors = {
@@ -170,11 +173,11 @@ function logoplotChart(selection) {
        'unknown': "#cccccc"
       };
       if(colorScheme == "functional"){
-        var colorMap = function(key){return functionalColors[key]};
         dataToPlot.forEach(function(d){
-          d["colors"] = functionalColors[d["mutation"]]
+          d["colors_mutation"] = functionalColors[d["mutation"]]
         })
       }
+      else if(colorScheme == 'custom'){}
       else{
         var colorMap = zScale;
       };
@@ -272,7 +275,7 @@ function logoplotChart(selection) {
           // desired x, y position, scaled, and then moved back by the same amount.
           return `translate(+${x} +${y}) scale(${widthScale} ${scale}) translate(-${x} -${y})`;
         })
-        .attr("fill", d => d["colors"])
+        .attr("fill", d => d["colors_mutation"])
         .on("mouseover", showTooltip)
         .on("mouseout", hideTooltip);
     });

--- a/logoplot.js
+++ b/logoplot.js
@@ -174,19 +174,19 @@ function logoplotChart(selection) {
       };
       if(colorScheme == "functional"){
         dataToPlot.forEach(function(d){
-          d["colors_mutation"] = functionalColors[d["mutation"]]
+          d["color_for_mutation"] = functionalColors[d["mutation"]]
         })
       }
       else if(colorScheme == 'custom'){
         dataToPlot.forEach(function(d){
-          if(d["colors_mutation"] == 'functional'){
-            d["colors_mutation"] = functionalColors[d["mutation"]]
+          if(d["color_for_mutation"] == 'functional'){
+            d["color_for_mutation"] = functionalColors[d["mutation"]]
           }
         })
       }
       else{
         dataToPlot.forEach(function(d){
-          d["colors_mutation"] = zScale[d["mutation"]]
+          d["color_for_mutation"] = zScale[d["mutation"]]
         })
       };
       svg.select(".x-axis").call(xAxis.tickFormat(function(site, i) {
@@ -283,7 +283,7 @@ function logoplotChart(selection) {
           // desired x, y position, scaled, and then moved back by the same amount.
           return `translate(+${x} +${y}) scale(${widthScale} ${scale}) translate(-${x} -${y})`;
         })
-        .attr("fill", d => d["colors_mutation"])
+        .attr("fill", d => d["color_for_mutation"])
         .on("mouseover", showTooltip)
         .on("mouseout", hideTooltip);
     });

--- a/logoplot.js
+++ b/logoplot.js
@@ -68,7 +68,6 @@ function logoplotChart(selection) {
       else {
         var metric_name = data[0].metric_name;
       }
-
       xScale.domain(sites);
       zScale.domain(mutations);
 
@@ -172,11 +171,13 @@ function logoplotChart(selection) {
       };
       if(colorScheme == "functional"){
         var colorMap = function(key){return functionalColors[key]};
+        dataToPlot.forEach(function(d){
+          d["colors"] = functionalColors[d["mutation"]]
+        })
       }
       else{
         var colorMap = zScale;
       };
-
       svg.select(".x-axis").call(xAxis.tickFormat(function(site, i) {
         // Display a tick label for each site up to the maximum number of
         // allowed sites and then switch to displaying tick labels at a fixed
@@ -271,7 +272,7 @@ function logoplotChart(selection) {
           // desired x, y position, scaled, and then moved back by the same amount.
           return `translate(+${x} +${y}) scale(${widthScale} ${scale}) translate(-${x} -${y})`;
         })
-        .attr("fill", d => colorMap(d["mutation"]))
+        .attr("fill", d => d["colors"])
         .on("mouseover", showTooltip)
         .on("mouseout", hideTooltip);
     });


### PR DESCRIPTION
This PR allows the user to specify a color for each site/mutation/mutation-metric combination.

This is done in the following way:
- if the user would like to use a custom color scheme for the mutation plot, they add a column to the dataframe called "colors_mutation". If they do not add this column, the default "functional" color scheme is used. 
- for each row, the user puts either a valid hex color, in which case the mutation will be colored by that color, or "functional", in which case the mutation will use the default functional color scheme.
- invalid strings or blank cells will default to black. 

@huddlej: this is certainly not elegant so I would appreciate any feedback! For example, what do you think of the column name "colors_mutation"? I didn't want to call it just colors because the column only modifies the mutation plot. I also didn't want it to start with mutation because I thought that would be confusing with the "mut_" columns for the values.