### PR TITLE
Provide more information about what failed when URLs can't be loaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,13 @@
     <div class="row mb-5 border-top border-bottom pt-3 pb-3">
       <div class="col-8">
         <div class="alert alert-danger" role="alert" id="dataFormFieldAlert" hidden>
-          <strong>Error reading the data URL!</strong>
-          Please review the URL below or check the contents of the datafile by reviewing the
-          <a href="https://dms-view.github.io/docs/dataupload/" target="_blank">documentation</a>.
+          <p>
+            <strong>Error reading the data URL!</strong>
+            Please review the URL below or check the contents of the datafile by reviewing the
+            <a href="https://dms-view.github.io/docs/dataupload/" target="_blank">documentation</a>.
+          </p>
+
+          The response from the server was: <code></code>
         </div>
         <p><input id="data-url" text="text" class="form-control" placeholder="Data URL (relative or absolute paths allowed)" /></p>
         <p>
@@ -65,9 +69,13 @@
       </div>
       <div class="col-4">
         <div class="alert alert-danger" role="alert" id="proteinFormFieldAlert" hidden>
-          <strong>Error reading the protein structure URL!</strong>
-          Please review the URL below or check the contents of the protein structure by reviewing the
-          <a href="https://dms-view.github.io/docs/dataupload/" target="_blank">documentation</a>.
+          <p>
+            <strong>Error reading the protein structure URL!</strong>
+            Please review the URL below or check the contents of the protein structure by reviewing the
+            <a href="https://dms-view.github.io/docs/dataupload/" target="_blank">documentation</a>.
+          </p>
+
+          The response from the server was: <code></code>
         </div>
         <div class="row">
           <p><input id="pdb-url" text="text" class="form-control" placeholder="PDB URL" /></p>
@@ -88,9 +96,13 @@
     <div id="description" class="row mt-3">
       <div class="col-12">
         <div class="alert alert-danger" role="alert" id="markdownFormFieldAlert" hidden>
-          <strong>Error reading the description URL!</strong>
-          Please review the URL below or check the contents of the description markdown by reviewing the
-          <a href="https://dms-view.github.io/docs/dataupload/" target="_blank">documentation</a>.
+          <p>
+            <strong>Error reading the description URL!</strong>
+            Please review the URL below or check the contents of the description markdown by reviewing the
+            <a href="https://dms-view.github.io/docs/dataupload/" target="_blank">documentation</a>.
+          </p>
+
+          The response from the server was: <code></code>
         </div>
         <p><input id="markdown-url" text="text" class="form-control" placeholder="markdown URL" /></p>
         <div id="markdown-output"></div>

--- a/main.js
+++ b/main.js
@@ -355,8 +355,10 @@ function renderDataUrl (dataUrl, dataFieldId, dataType) {
     // Let the user know their URL could not be loaded.
     console.log("Failed to load data: " + reason);
     d3.select("#" + dataFieldId).classed('is-invalid', true);
+
     // show the error
-    dataAlert.hidden = false
+    d3.select(dataAlert).select("code").text(reason.message);
+    dataAlert.hidden = false;
   });
 }
 


### PR DESCRIPTION
Adds a place to store the server's response when the user requests a URL that
can't be loaded. This should help users debug a little more than telling them
the URL couldn't be loaded.

Related to #154.