### PR TITLE
Missing protein site

### DIFF
--- a/assets/js/line_plot_zoom.js
+++ b/assets/js/line_plot_zoom.js
@@ -274,12 +274,14 @@ function genomeLineChart() {
         .classed("selected", true);
 
     // update the PROTEIN structure
-    if(!missingData.includes(circleData.protein_site) &&
-       !missingData.includes(circleData.protein_chain)){
+    console.log(missingData.includes(circleData.protein_chain))
+    if(!missingData.includes(circleData.protein_site)){
       circleData.protein_chain.forEach(function(chain){
-        selectSiteOnProtein(":" + chain + " and " +
-          circleData.protein_site,
-          color_key[circleData.site]);
+        if(!missingData.includes(chain)){
+          selectSiteOnProtein(":" + chain + " and " +
+            circleData.protein_site,
+            color_key[circleData.site]);
+        }
       });
     }
   };

--- a/assets/js/line_plot_zoom.js
+++ b/assets/js/line_plot_zoom.js
@@ -274,7 +274,8 @@ function genomeLineChart() {
         .classed("selected", true);
 
     // update the PROTEIN structure
-    if(!missingData.includes(circleData.protein_site)){
+    if(!missingData.includes(circleData.protein_site) &&
+       !missingData.includes(circleData.protein_chain.protein_site)){
       circleData.protein_chain.forEach(function(chain){
         selectSiteOnProtein(":" + chain + " and " +
           circleData.protein_site,

--- a/assets/js/line_plot_zoom.js
+++ b/assets/js/line_plot_zoom.js
@@ -154,6 +154,10 @@ function genomeLineChart() {
     var colors = {},
         min_y_value = d3.min(data, d => +d.metric),
         range = d3.max(data, d => +d.metric) - min_y_value;
+    // if only 1 site, set range to 1
+    if(range == 0){
+      range = 1;
+    }
     data.forEach(function(d) {
       if(d.metric == undefined){
         colors[d.site] = greyColor
@@ -270,11 +274,13 @@ function genomeLineChart() {
         .classed("selected", true);
 
     // update the PROTEIN structure
-    circleData.protein_chain.forEach(function(chain){
-      selectSiteOnProtein(":" + chain + " and " +
-        circleData.protein_site,
-        color_key[circleData.site]);
-    });
+    if(!missingData.includes(circleData.protein_site)){
+      circleData.protein_chain.forEach(function(chain){
+        selectSiteOnProtein(":" + chain + " and " +
+          circleData.protein_site,
+          color_key[circleData.site]);
+      });
+    }
   };
 
   var deselectSite = function(circlePoint){

--- a/assets/js/line_plot_zoom.js
+++ b/assets/js/line_plot_zoom.js
@@ -275,7 +275,7 @@ function genomeLineChart() {
 
     // update the PROTEIN structure
     if(!missingData.includes(circleData.protein_site) &&
-       !missingData.includes(circleData.protein_chain.protein_site)){
+       !missingData.includes(circleData.protein_chain)){
       circleData.protein_chain.forEach(function(chain){
         selectSiteOnProtein(":" + chain + " and " +
           circleData.protein_site,


### PR DESCRIPTION
This PR handles corner cases involved in the missing data for the protein site/chain _and_ when there is only one line of data. 

1. missing protein chain / protein site
Before this PR, if the user tried to select a site with a _valid_ (not missing value) chain and a _valid_ (not missing value) site but the chain/site combo did not exist in the pdb then nothing happened. However, if either the protein chain or the protein site is a missing value then all of the sites were selected. Now, the code first checks that neither the protein site nor the protein chain are missing values before calling the `selectSiteOnProtein` function.

2. Weird color scheme with only one site
@jbloom's small test case revealed another, separate 🐛! The site plot color scheme is defined by the range, specifically at some point we _divide_ by the range. If you only have one site, the range is zero. And dividing by zero is undefined. Now, the code just checks if the range is zero and, if so, sets the range to 1.

I've attached the small test datasets I used to debug. The difference between `test1` and `test1000` is that test 1 includes a real value for protein site _and_ it exists on the protein structure. `test1000` includes a real value for the protein site _but_ the site does not exist on the protein structure. 

This resolves #169 