### PR TITLE
Color protein chains

### DIFF
--- a/assets/js/line_plot_zoom.js
+++ b/assets/js/line_plot_zoom.js
@@ -510,9 +510,6 @@ function genomeLineChart() {
         })
       });
       chart.protein_chain_colorscheme = createProteinColorScheme([...new Set(protein_chains)]);
-      if(protein){
-        colorWholeProtein(protein, polymerSelect.value)
-      }
       // Group data by condition and site and only takes the first of the sites,
       // to get site-level data.
       data = d3.rollup(long_data, v => v[0], d => d.condition, d => d.metric_name, d => d.site)
@@ -577,6 +574,14 @@ function genomeLineChart() {
           focus.classed("brush_select", true).classed("brush_deselect", false)
         } else if ( this.value === 'deselect' ) {
            focus.classed("brush_select", false).classed("brush_deselect", true)
+        }
+      });
+      d3.selectAll("input[name='colorCheckbox']").on("change", function(){
+        if(this.checked && chart && protein){
+              colorWholeProtein(protein, polymerSelect.value, true)
+          }
+        else if(!(this.checked) && protein){
+          colorWholeProtein(protein, polymerSelect.value, false)
         }
       });
 

--- a/assets/js/line_plot_zoom.js
+++ b/assets/js/line_plot_zoom.js
@@ -454,6 +454,7 @@ function genomeLineChart() {
 
       var site_metrics = []
       var mut_metrics = []
+      var protein_chains = []
       Object.keys(alldata[0]).forEach(function(col){
         if (col.startsWith("site_")){
           site_metrics.push(col)
@@ -490,6 +491,9 @@ function genomeLineChart() {
               "condition": row["condition"],
               "metric": metric_value,
               "metric_name": colname});
+              row["protein_chain"].split(" ").forEach(function(d){
+                protein_chains.push(d)
+              })
           }
           else if (colname.startsWith('mut_')) {
             mut_long_data.push({
@@ -505,6 +509,7 @@ function genomeLineChart() {
           }
         })
       });
+      chart.protein_chain_colorscheme = createProteinColorScheme([...new Set(protein_chains)]);
       // Group data by condition and site and only takes the first of the sites,
       // to get site-level data.
       data = d3.rollup(long_data, v => v[0], d => d.condition, d => d.metric_name, d => d.site)

--- a/assets/js/line_plot_zoom.js
+++ b/assets/js/line_plot_zoom.js
@@ -510,6 +510,13 @@ function genomeLineChart() {
         })
       });
       chart.protein_chain_colorscheme = createProteinColorScheme([...new Set(protein_chains)]);
+      if(protein){
+        protein.addRepresentation(polymerSelect.value, {
+          sele: "polymer",
+          name: "polymer",
+          color: chart.protein_chain_colorscheme
+      })
+    }
       // Group data by condition and site and only takes the first of the sites,
       // to get site-level data.
       data = d3.rollup(long_data, v => v[0], d => d.condition, d => d.metric_name, d => d.site)

--- a/assets/js/line_plot_zoom.js
+++ b/assets/js/line_plot_zoom.js
@@ -511,12 +511,8 @@ function genomeLineChart() {
       });
       chart.protein_chain_colorscheme = createProteinColorScheme([...new Set(protein_chains)]);
       if(protein){
-        protein.addRepresentation(polymerSelect.value, {
-          sele: "polymer",
-          name: "polymer",
-          color: chart.protein_chain_colorscheme
-      })
-    }
+        colorWholeProtein(protein, polymerSelect.value)
+      }
       // Group data by condition and site and only takes the first of the sites,
       // to get site-level data.
       data = d3.rollup(long_data, v => v[0], d => d.condition, d => d.metric_name, d => d.site)

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -19,7 +19,7 @@ var clearbuttonchange;
 let protein;
 const greyColor = "#999999";
 const targetChainsColor = greyColor;
-const alternativeChainsColor = 'black';
+const alternativeChainsColor = '#555555';
 
 var fontPath = "/assets/fonts/DejaVuSansMonoBold_SeqLogo.ttf";
 var fontObject;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -18,6 +18,8 @@ var clearbuttonchange;
 
 let protein;
 const greyColor = "#999999";
+const targetChainsColor = greyColor;
+const alternativeChainsColor = 'black';
 
 var fontPath = "/assets/fonts/DejaVuSansMonoBold_SeqLogo.ttf";
 var fontObject;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -288,7 +288,7 @@ function renderPdb(data, dataUrl) {
   protein = data;
   protein.setRotation([2, 0, 0])
   protein.autoView()
-  colorWholeProtein(protein, polymerSelect.value)
+  colorWholeProtein(protein, polymerSelect.value, false)
 
   // If data have been loaded into the site plot, select any sites from that
   // panel in the protein view, too.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -286,17 +286,7 @@ function renderPdb(data, dataUrl) {
   protein = data;
   protein.setRotation([2, 0, 0])
   protein.autoView()
-  if(chart){
-    protein.addRepresentation(polymerSelect.value, {
-      sele: "polymer",
-      name: "polymer",
-      color: chart.protein_chain_colorscheme
-  })}else{
-    protein.addRepresentation(polymerSelect.value, {
-      sele: "polymer",
-      name: "polymer",
-      color: greyColor
-  })}
+  colorWholeProtein(protein, polymerSelect.value)
 
   // If data have been loaded into the site plot, select any sites from that
   // panel in the protein view, too.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -286,11 +286,17 @@ function renderPdb(data, dataUrl) {
   protein = data;
   protein.setRotation([2, 0, 0])
   protein.autoView()
-  protein.addRepresentation(polymerSelect.value, {
-    sele: "polymer",
-    name: "polymer",
-    color: greyColor
-  });
+  if(chart){
+    protein.addRepresentation(polymerSelect.value, {
+      sele: "polymer",
+      name: "polymer",
+      color: chart.protein_chain_colorscheme
+  })}else{
+    protein.addRepresentation(polymerSelect.value, {
+      sele: "polymer",
+      name: "polymer",
+      color: greyColor
+  })}
 
   // If data have been loaded into the site plot, select any sites from that
   // panel in the protein view, too.

--- a/assets/js/prot_struct.js
+++ b/assets/js/prot_struct.js
@@ -10,8 +10,8 @@ stage.setParameters({
 function createProteinColorScheme(targetChains){
   targetChains = ":" + targetChains.join(" or :");
   return NGL.ColormakerRegistry.addSelectionScheme([
-    ["red", targetChains],
-    [greyColor, "*"]
+    [alternativeChainsColor, targetChains],
+    [targetChainsColor, "*"]
   ]);
 }
 

--- a/assets/js/prot_struct.js
+++ b/assets/js/prot_struct.js
@@ -55,8 +55,8 @@ function deselectSiteOnProtein(siteString) {
 
 var polymerSelect = document.querySelector('select[name="polymerSelect"]');
 
-function colorWholeProtein(_protein, representation){
-  if(chart){
+function colorWholeProtein(_protein, representation, colorChains){
+  if(colorChains){
     _protein.addRepresentation(representation, {
         sele: "polymer",
         name: "polymer",

--- a/assets/js/prot_struct.js
+++ b/assets/js/prot_struct.js
@@ -55,22 +55,26 @@ function deselectSiteOnProtein(siteString) {
 
 var polymerSelect = document.querySelector('select[name="polymerSelect"]');
 
+function colorWholeProtein(_protein, representation){
+  if(chart){
+    _protein.addRepresentation(representation, {
+        sele: "polymer",
+        name: "polymer",
+        color: chart.protein_chain_colorscheme
+      })
+  }else{
+    _protein.addRepresentation(representation, {
+        sele: "polymer",
+        name: "polymer",
+        color: greyColor
+      })
+  }
+}
+
 polymerSelect.addEventListener('change', function(e) {
   stage.getRepresentationsByName("polymer").dispose()
   stage.eachComponent(function(o) {
-      if(chart){
-        o.addRepresentation(e.target.value, {
-            sele: "polymer",
-            name: "polymer",
-            color: chart.protein_chain_colorscheme
-          })
-      }else{
-        o.addRepresentation(e.target.value, {
-            sele: "polymer",
-            name: "polymer",
-            color: greyColor
-          })
-      }
+    colorWholeProtein(o, e.target.value)
       // on change, reselect the points so they are "on top"
     d3.selectAll(".selected").data().forEach(function(element) {
       element.protein_chain.forEach(function(chain){

--- a/assets/js/prot_struct.js
+++ b/assets/js/prot_struct.js
@@ -6,6 +6,15 @@ stage.setParameters({
   backgroundColor: "white"
 });
 
+// color scheme
+function createProteinColorScheme(targetChains){
+  targetChains = ":" + targetChains.join(" or :");
+  return NGL.ColormakerRegistry.addSelectionScheme([
+    ["red", targetChains],
+    [greyColor, "*"]
+  ]);
+}
+
 // Handle window resizing
 window.addEventListener("resize", function(event) {
   stage.handleResize();
@@ -30,6 +39,15 @@ function selectSiteOnProtein(siteString, color) {
 }
 }
 
+function selectChainOnProtein(chainString, representation){
+  if(protein){
+    protein.addRepresentation(representation, {
+      name: "target polymer",
+      color: '#000000'
+    }).setSelection(chainString)
+  }
+}
+
 // remove color from a site
 function deselectSiteOnProtein(siteString) {
   stage.getRepresentationsByName(siteString).dispose()
@@ -40,11 +58,19 @@ var polymerSelect = document.querySelector('select[name="polymerSelect"]');
 polymerSelect.addEventListener('change', function(e) {
   stage.getRepresentationsByName("polymer").dispose()
   stage.eachComponent(function(o) {
-    o.addRepresentation(e.target.value, {
-        sele: "polymer",
-        name: "polymer",
-        color: greyColor
-      })
+      if(chart){
+        o.addRepresentation(e.target.value, {
+            sele: "polymer",
+            name: "polymer",
+            color: chart.protein_chain_colorscheme
+          })
+      }else{
+        o.addRepresentation(e.target.value, {
+            sele: "polymer",
+            name: "polymer",
+            color: greyColor
+          })
+      }
       // on change, reselect the points so they are "on top"
     d3.selectAll(".selected").data().forEach(function(element) {
       element.protein_chain.forEach(function(chain){

--- a/assets/js/prot_struct.js
+++ b/assets/js/prot_struct.js
@@ -10,8 +10,8 @@ stage.setParameters({
 function createProteinColorScheme(targetChains){
   targetChains = ":" + targetChains.join(" or :");
   return NGL.ColormakerRegistry.addSelectionScheme([
-    [alternativeChainsColor, targetChains],
-    [targetChainsColor, "*"]
+    [targetChainsColor, targetChains],
+    [alternativeChainsColor, "*"]
   ]);
 }
 

--- a/index.html
+++ b/index.html
@@ -89,6 +89,8 @@
             <option value="surface">surface</option>
           </select>
           <button id="protein_plot_download" type="button" class="btn btn-light float-right"><img src="/assets/images/download.svg" /> Download PNG</button>
+          <input type="checkbox" id="color" name="colorCheckbox" value="colorChains">
+          <label for="color">color chains</label><br>
         </div>
         <div id="protein" style="width: 400px; height: 550px;"></div>
       </div>


### PR DESCRIPTION
This PR will implement an option to allow users to color the chains in the protein structure that data are mapped onto differently from all other chains in the protein. This will hopefully serve two purposes: highlighting the data more clearly and differentiating between the protein of interest and other structures in the pdb file such as ligands, antibodies, etc. 

As of the initial opening of this PR, the changes are to automatically color the protein chains in the data file as grey and all other chains as black. 

Here is the current master
![image](https://user-images.githubusercontent.com/13006030/88337582-cd2ed200-cceb-11ea-9f0a-ebc159efde82.png)
Here is the current PR
![image](https://user-images.githubusercontent.com/13006030/88337619-d9b32a80-cceb-11ea-85de-1de532f02869.png)

Before this PR is merged we would like to add three other components: 
1. Allow the user to toggle between everything being the same color vs. the chains in the data file being a different color
2. Allow the user to pick the two colors in the alternative color scheme
3. track all of this info in the URL

This PR would resolve #150.