### PR TITLE
Indicate shared first authorship with a footnote

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -8,10 +8,10 @@ tags:
   - protein evolution
   - data visualization
 authors:
-  - name: Sarah K. Hilton*
+  - name: Sarah K. Hilton^[These authors contributed equally to this work.]
     affiliation: "1, 2"
     orcid: 0000-0001-9278-3644
-  - name: John Huddleston*
+  - name: John Huddleston$^*$
     affiliation: "3, 4"
     orcid: 0000-0002-4250-2063
   - name: Allison Black


### PR DESCRIPTION
Adds a footnote to indicate equal contribution of co-first authors, [as recommended by JOSS](https://github.com/openjournals/joss-reviews/issues/2353#issuecomment-674027760).